### PR TITLE
feat: add Claude Skills management module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "shared",
  "sqlx",
  "tauri",
@@ -110,6 +111,7 @@ dependencies = [
  "typeshare",
  "urlencoding",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -1260,6 +1262,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -4592,6 +4600,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6223,6 +6244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6641,6 +6668,18 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
 
 [[package]]
 name = "whoami"
@@ -7179,6 +7218,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/packages/ui/app/skills/page.tsx
+++ b/packages/ui/app/skills/page.tsx
@@ -1,0 +1,5 @@
+import { Skills } from "@/modules/skills";
+
+export default function SkillsPage() {
+  return <Skills />;
+}

--- a/packages/ui/src/bridges/skills-bridge.ts
+++ b/packages/ui/src/bridges/skills-bridge.ts
@@ -1,0 +1,42 @@
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  SkillSummary,
+  SkillDetail,
+  SkillCommandResult,
+} from "../generated/typeshare-types";
+
+/**
+ * Skills Bridge - Frontend interface for Claude Skills management
+ */
+export class SkillsBridge {
+  static async listSkills(): Promise<SkillSummary[]> {
+    return invoke<SkillSummary[]>("list_skills");
+  }
+
+  static async getSkillDetail(name: string): Promise<SkillDetail> {
+    return invoke<SkillDetail>("get_skill_detail", { name });
+  }
+
+  static async updateSkill(
+    name: string,
+    content: string,
+  ): Promise<SkillCommandResult> {
+    return invoke<SkillCommandResult>("update_skill", { name, content });
+  }
+
+  static async installSkill(name: string): Promise<SkillCommandResult> {
+    return invoke<SkillCommandResult>("install_skill", { name });
+  }
+
+  static async uninstallSkill(path: string): Promise<SkillCommandResult> {
+    return invoke<SkillCommandResult>("uninstall_skill", { path });
+  }
+
+  static async enableSkill(name: string): Promise<SkillCommandResult> {
+    return invoke<SkillCommandResult>("enable_skill", { name });
+  }
+
+  static async disableSkill(name: string): Promise<SkillCommandResult> {
+    return invoke<SkillCommandResult>("disable_skill", { name });
+  }
+}

--- a/packages/ui/src/components/app-sidebar/constants.ts
+++ b/packages/ui/src/components/app-sidebar/constants.ts
@@ -5,6 +5,7 @@ import {
   BarChart3,
   Gauge,
   Sparkles,
+  Puzzle,
 } from "lucide-react";
 import type { NavItem } from "./types";
 
@@ -33,6 +34,11 @@ export const NAV_ITEMS = [
     id: "usage",
     label: "Usage",
     icon: Gauge,
+  },
+  {
+    id: "skills",
+    label: "Skills",
+    icon: Puzzle,
   },
   {
     id: "wrapped",

--- a/packages/ui/src/components/app-sidebar/use-service.ts
+++ b/packages/ui/src/components/app-sidebar/use-service.ts
@@ -10,6 +10,7 @@ const ROUTE_MAP: Record<string, string> = {
   tools: "/tools",
   analytics: "/analytics",
   usage: "/usage",
+  skills: "/skills",
   wrapped: "/wrapped",
 } as const;
 
@@ -18,6 +19,7 @@ const NAV_ROUTES = [
   { prefix: "/tools", id: "tools" },
   { prefix: "/analytics", id: "analytics" },
   { prefix: "/usage", id: "usage" },
+  { prefix: "/skills", id: "skills" },
   { prefix: "/wrapped", id: "wrapped" },
 ] as const;
 

--- a/packages/ui/src/components/markdown-viewer/index.tsx
+++ b/packages/ui/src/components/markdown-viewer/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import "highlight.js/styles/github.css";
+import { markdownComponents } from "./markdown-components";
+
+interface MarkdownViewerProps {
+  content: string;
+  className?: string;
+}
+
+export function MarkdownViewer({ content, className }: MarkdownViewerProps) {
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={markdownComponents}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/ui/src/components/markdown-viewer/markdown-components.tsx
+++ b/packages/ui/src/components/markdown-viewer/markdown-components.tsx
@@ -1,0 +1,69 @@
+import type { Components } from "react-markdown";
+
+export const markdownComponents: Partial<Components> = {
+  p: ({ children }) => <p className="mb-3 last:mb-0">{children}</p>,
+  pre: ({ children }) => (
+    <pre className="my-3 overflow-x-auto rounded-lg border border-border bg-muted p-3 text-xs leading-relaxed [&>code]:bg-transparent [&>code]:p-0">
+      {children}
+    </pre>
+  ),
+  code: ({ children, className }) => {
+    if (className?.startsWith("hljs") || className?.includes("language-"))
+      return <code className={className}>{children}</code>;
+    return (
+      <code className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[13px]">
+        {children}
+      </code>
+    );
+  },
+  ul: ({ children }) => (
+    <ul className="mb-3 list-disc pl-5 last:mb-0">{children}</ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="mb-3 list-decimal pl-5 last:mb-0">{children}</ol>
+  ),
+  li: ({ children }) => <li className="mb-1">{children}</li>,
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      className="text-primary underline underline-offset-2 hover:text-primary/80"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  ),
+  h1: ({ children }) => (
+    <h1 className="mb-3 text-base font-semibold">{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="mb-2 text-sm font-semibold">{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mb-2 text-sm font-medium">{children}</h3>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="my-3 border-l-2 border-border pl-3 text-muted-foreground">
+      {children}
+    </blockquote>
+  ),
+  table: ({ children }) => (
+    <div className="my-3 overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-xs">{children}</table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-b border-border bg-muted px-3 py-1.5 text-left text-xs font-medium">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border-b border-border px-3 py-1.5 text-xs">
+      {children}
+    </td>
+  ),
+  hr: () => <hr className="my-4 border-border" />,
+  strong: ({ children }) => (
+    <strong className="font-semibold">{children}</strong>
+  ),
+};

--- a/packages/ui/src/modules/session-detail/components/viewers/markdown-viewer/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/viewers/markdown-viewer/index.tsx
@@ -1,26 +1,3 @@
 "use client";
 
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
-import "highlight.js/styles/github.css";
-import { markdownComponents } from "../../shared/markdown-components";
-
-interface MarkdownViewerProps {
-  content: string;
-  className?: string;
-}
-
-export function MarkdownViewer({ content, className }: MarkdownViewerProps) {
-  return (
-    <div className={className}>
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeHighlight]}
-        components={markdownComponents}
-      >
-        {content}
-      </ReactMarkdown>
-    </div>
-  );
-}
+export { MarkdownViewer } from "@/components/markdown-viewer";

--- a/packages/ui/src/modules/skills/components/index.ts
+++ b/packages/ui/src/modules/skills/components/index.ts
@@ -1,0 +1,5 @@
+export { SkillList } from "./skill-list";
+export { SkillCard } from "./skill-card";
+export { SkillDetailView } from "./skill-detail";
+export { SkillEditor } from "./skill-editor";
+export { InstallDialog } from "./install-dialog";

--- a/packages/ui/src/modules/skills/components/install-dialog/index.tsx
+++ b/packages/ui/src/modules/skills/components/install-dialog/index.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
+import { useService } from "./use-service";
+import type { InstallDialogProps } from "./types";
+
+export function InstallDialog({ open, onOpenChange }: InstallDialogProps) {
+  const { pluginName, setPluginName, isInstalling, installResult, onInstall } =
+    useService(() => onOpenChange(false));
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Install Plugin</SheetTitle>
+          <SheetDescription>
+            Enter the plugin name to install via Claude CLI.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="px-4">
+          <Input
+            placeholder="e.g. @anthropic/skill-name"
+            value={pluginName}
+            onChange={(e) => setPluginName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !isInstalling) onInstall();
+            }}
+            disabled={isInstalling}
+          />
+          {installResult && !installResult.success && (
+            <p className="mt-2 text-xs text-destructive">
+              {installResult.message}
+            </p>
+          )}
+        </div>
+
+        <SheetFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isInstalling}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={onInstall}
+            disabled={isInstalling || !pluginName.trim()}
+          >
+            {isInstalling && (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            )}
+            Install
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/ui/src/modules/skills/components/install-dialog/types.ts
+++ b/packages/ui/src/modules/skills/components/install-dialog/types.ts
@@ -1,0 +1,4 @@
+export interface InstallDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}

--- a/packages/ui/src/modules/skills/components/install-dialog/use-service.ts
+++ b/packages/ui/src/modules/skills/components/install-dialog/use-service.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { SkillsBridge } from "@/bridges/skills-bridge";
+
+export function useService(onClose: () => void) {
+  const queryClient = useQueryClient();
+  const [pluginName, setPluginName] = useState("");
+
+  const installMutation = useMutation({
+    mutationFn: SkillsBridge.installSkill,
+    onSuccess: (result) => {
+      if (result.success) {
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+        setPluginName("");
+        onClose();
+      }
+    },
+  });
+
+  const handleInstall = () => {
+    const trimmed = pluginName.trim();
+    if (trimmed) {
+      installMutation.mutate(trimmed);
+    }
+  };
+
+  return {
+    pluginName,
+    setPluginName,
+    isInstalling: installMutation.isPending,
+    installResult: installMutation.data,
+    installError: installMutation.error,
+    onInstall: handleInstall,
+  };
+}

--- a/packages/ui/src/modules/skills/components/skill-card/index.tsx
+++ b/packages/ui/src/modules/skills/components/skill-card/index.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Link2, Trash2 } from "lucide-react";
+import type { SkillCardProps } from "./types";
+
+export function SkillCard({
+  skill,
+  onSelect,
+  onUninstall,
+  isUninstalling,
+}: SkillCardProps) {
+  return (
+    <Card
+      className="group cursor-pointer gap-3 py-4 transition-colors hover:bg-accent/50"
+      onClick={() => onSelect(skill.name)}
+    >
+      <CardHeader className="px-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <CardTitle className="truncate text-sm">{skill.name}</CardTitle>
+              {skill.isSymlink && (
+                <Link2 className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+            </div>
+          </div>
+          <Badge variant="outline" className="shrink-0 text-[10px]">
+            v{skill.version}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="px-4">
+        <p className="line-clamp-2 text-xs text-muted-foreground">
+          {skill.description || "No description"}
+        </p>
+        <div className="mt-3 flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            {skill.source && (
+              <Badge variant="secondary" className="text-[10px]">
+                {skill.source}
+              </Badge>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUninstall(skill.path);
+            }}
+            disabled={isUninstalling}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/modules/skills/components/skill-card/types.ts
+++ b/packages/ui/src/modules/skills/components/skill-card/types.ts
@@ -1,0 +1,8 @@
+import type { SkillSummary } from "@/generated/typeshare-types";
+
+export interface SkillCardProps {
+  skill: SkillSummary;
+  onSelect: (name: string) => void;
+  onUninstall: (name: string) => void;
+  isUninstalling: boolean;
+}

--- a/packages/ui/src/modules/skills/components/skill-detail/index.tsx
+++ b/packages/ui/src/modules/skills/components/skill-detail/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { CardLoading } from "@/components/card-loading";
+import { CardError } from "@/components/card-error";
+import { MarkdownViewer } from "@/components/markdown-viewer";
+import { ArrowLeft, Pencil, Link2 } from "lucide-react";
+import { useService } from "./use-service";
+import type { SkillDetailViewProps } from "./types";
+
+export function SkillDetailView({
+  name,
+  onBack,
+  onEdit,
+}: SkillDetailViewProps) {
+  const { detail, isLoading, isError } = useService(name);
+
+  if (isLoading) return <CardLoading showTitle />;
+  if (isError || !detail) return <CardError message="Failed to load skill" />;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={onBack}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <div className="flex flex-1 items-center gap-2">
+          <h2 className="text-sm font-semibold">{detail.name}</h2>
+          {detail.isSymlink && (
+            <Link2 className="size-3.5 text-muted-foreground" />
+          )}
+          <Badge variant="outline" className="text-[10px]">
+            v{detail.version}
+          </Badge>
+        </div>
+        {!detail.isReadonly && (
+          <Button variant="outline" size="sm" onClick={onEdit}>
+            <Pencil className="mr-1.5 size-3.5" />
+            Edit
+          </Button>
+        )}
+      </div>
+
+      {detail.description && (
+        <p className="text-xs text-muted-foreground">{detail.description}</p>
+      )}
+
+      <Card className="gap-0 py-0">
+        <CardHeader className="border-b px-4 py-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            SKILL.md
+          </span>
+        </CardHeader>
+        <CardContent className="p-4">
+          <MarkdownViewer
+            content={detail.markdownBody || "*No content*"}
+            className="prose-sm"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/skills/components/skill-detail/types.ts
+++ b/packages/ui/src/modules/skills/components/skill-detail/types.ts
@@ -1,0 +1,5 @@
+export interface SkillDetailViewProps {
+  name: string;
+  onBack: () => void;
+  onEdit: () => void;
+}

--- a/packages/ui/src/modules/skills/components/skill-detail/use-service.ts
+++ b/packages/ui/src/modules/skills/components/skill-detail/use-service.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { SkillsBridge } from "@/bridges/skills-bridge";
+
+export function useService(name: string) {
+  const detailQuery = useQuery({
+    queryKey: ["skill-detail", name],
+    queryFn: () => SkillsBridge.getSkillDetail(name),
+    enabled: !!name,
+  });
+
+  return {
+    detail: detailQuery.data,
+    isLoading: detailQuery.isLoading,
+    isError: detailQuery.isError,
+  };
+}

--- a/packages/ui/src/modules/skills/components/skill-editor/index.tsx
+++ b/packages/ui/src/modules/skills/components/skill-editor/index.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { CardLoading } from "@/components/card-loading";
+import { MarkdownViewer } from "@/components/markdown-viewer";
+import { ArrowLeft, Save, Loader2 } from "lucide-react";
+import { useService } from "./use-service";
+import type { SkillEditorProps } from "./types";
+
+export function SkillEditor({ name, onDone, onBack }: SkillEditorProps) {
+  const { content, setContent, isLoading, isSaving, onSave } =
+    useService(name);
+
+  if (isLoading) return <CardLoading showTitle />;
+
+  const handleSave = () => {
+    onSave(undefined, {
+      onSuccess: (result) => {
+        if (result.success) {
+          onDone();
+        }
+      },
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={onBack}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <h2 className="flex-1 text-sm font-semibold">Editing: {name}</h2>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={onBack}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isSaving}>
+            {isSaving ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <Save className="mr-1.5 size-3.5" />
+            )}
+            Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-2 gap-4">
+        <div className="flex flex-col overflow-hidden rounded-lg border border-border">
+          <div className="border-b px-3 py-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Source
+            </span>
+          </div>
+          <textarea
+            className="flex-1 resize-none bg-muted/30 p-3 font-mono text-xs leading-relaxed outline-none"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            spellCheck={false}
+          />
+        </div>
+
+        <div className="flex flex-col overflow-hidden rounded-lg border border-border">
+          <div className="border-b px-3 py-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Preview
+            </span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-3">
+            <MarkdownViewer content={content} className="prose-sm" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/skills/components/skill-editor/types.ts
+++ b/packages/ui/src/modules/skills/components/skill-editor/types.ts
@@ -1,0 +1,5 @@
+export interface SkillEditorProps {
+  name: string;
+  onDone: () => void;
+  onBack: () => void;
+}

--- a/packages/ui/src/modules/skills/components/skill-editor/use-service.ts
+++ b/packages/ui/src/modules/skills/components/skill-editor/use-service.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { SkillsBridge } from "@/bridges/skills-bridge";
+
+export function useService(name: string) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState<string | null>(null);
+
+  const detailQuery = useQuery({
+    queryKey: ["skill-detail", name],
+    queryFn: () => SkillsBridge.getSkillDetail(name),
+    enabled: !!name,
+  });
+
+  // Use local content if user has started editing, otherwise use fetched data
+  const displayContent = content ?? detailQuery.data?.rawContent ?? "";
+
+  const handleContentChange = useCallback((value: string) => {
+    setContent(value);
+  }, []);
+
+  const saveMutation = useMutation({
+    mutationFn: () => SkillsBridge.updateSkill(name, displayContent),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["skill-detail", name] });
+      queryClient.invalidateQueries({ queryKey: ["skills"] });
+    },
+  });
+
+  return {
+    content: displayContent,
+    setContent: handleContentChange,
+    isLoading: detailQuery.isLoading,
+    isSaving: saveMutation.isPending,
+    saveResult: saveMutation.data,
+    saveError: saveMutation.error,
+    onSave: saveMutation.mutate,
+  };
+}

--- a/packages/ui/src/modules/skills/components/skill-list/index.tsx
+++ b/packages/ui/src/modules/skills/components/skill-list/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { CardEmpty } from "@/components/card-empty";
+import { Puzzle } from "lucide-react";
+import { SkillCard } from "../skill-card";
+import type { SkillListProps } from "./types";
+
+export function SkillList({
+  skills,
+  onSelect,
+  onUninstall,
+  isUninstalling,
+}: SkillListProps) {
+  if (skills.length === 0) {
+    return (
+      <CardEmpty
+        message="No skills installed. Click 'Install Plugin' to add one."
+        icon={<Puzzle className="size-8 text-muted-foreground" />}
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2">
+      {skills.map((skill) => (
+        <SkillCard
+          key={skill.path}
+          skill={skill}
+          onSelect={onSelect}
+          onUninstall={onUninstall}
+          isUninstalling={isUninstalling}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/skills/components/skill-list/types.ts
+++ b/packages/ui/src/modules/skills/components/skill-list/types.ts
@@ -1,0 +1,8 @@
+import type { SkillSummary } from "@/generated/typeshare-types";
+
+export interface SkillListProps {
+  skills: SkillSummary[];
+  onSelect: (name: string) => void;
+  onUninstall: (name: string) => void;
+  isUninstalling: boolean;
+}

--- a/packages/ui/src/modules/skills/index.tsx
+++ b/packages/ui/src/modules/skills/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { PageHeader } from "@/components/page-header";
+import { CardLoading } from "@/components/card-loading";
+import { CardError } from "@/components/card-error";
+import { SkillList, SkillDetailView, SkillEditor } from "./components";
+import { useService } from "./use-service";
+import { VIEW_MODE } from "./types";
+
+export function Skills() {
+  const {
+    skills,
+    isLoading,
+    isError,
+    refetch,
+    selectedSkill,
+    viewMode,
+    onSelectSkill,
+    onBack,
+    onEdit,
+    onEditDone,
+    onUninstall,
+    isUninstalling,
+  } = useService();
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <PageHeader title="Skills" />
+
+      <div className="flex-1 overflow-y-auto bg-muted/40">
+        <div className="mx-auto max-w-6xl p-6">
+          {isLoading && <CardLoading showTitle />}
+          {isError && (
+            <CardError
+              message="Failed to load skills"
+              onRetry={() => refetch()}
+            />
+          )}
+          {!isLoading && !isError && viewMode === VIEW_MODE.List && (
+            <SkillList
+              skills={skills}
+              onSelect={onSelectSkill}
+              onUninstall={onUninstall}
+              isUninstalling={isUninstalling}
+            />
+          )}
+          {viewMode === VIEW_MODE.Detail && selectedSkill && (
+            <SkillDetailView
+              name={selectedSkill}
+              onBack={onBack}
+              onEdit={onEdit}
+            />
+          )}
+          {viewMode === VIEW_MODE.Edit && selectedSkill && (
+            <SkillEditor
+              name={selectedSkill}
+              onDone={onEditDone}
+              onBack={onBack}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/skills/types.ts
+++ b/packages/ui/src/modules/skills/types.ts
@@ -1,0 +1,7 @@
+export const VIEW_MODE = {
+  List: "list",
+  Detail: "detail",
+  Edit: "edit",
+} as const;
+
+export type ViewMode = (typeof VIEW_MODE)[keyof typeof VIEW_MODE];

--- a/packages/ui/src/modules/skills/use-service.ts
+++ b/packages/ui/src/modules/skills/use-service.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { SkillsBridge } from "@/bridges/skills-bridge";
+import { VIEW_MODE, type ViewMode } from "./types";
+
+export function useService() {
+  const queryClient = useQueryClient();
+  const [selectedSkill, setSelectedSkill] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>(VIEW_MODE.List);
+
+  const skillsQuery = useQuery({
+    queryKey: ["skills"],
+    queryFn: SkillsBridge.listSkills,
+  });
+
+  const uninstallMutation = useMutation({
+    mutationFn: SkillsBridge.uninstallSkill,
+    onSuccess: (result) => {
+      if (result.success) {
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+        setViewMode(VIEW_MODE.List);
+        setSelectedSkill(null);
+      }
+    },
+  });
+
+  const handleSelectSkill = useCallback((name: string) => {
+    setSelectedSkill(name);
+    setViewMode(VIEW_MODE.Detail);
+  }, []);
+
+  const handleBack = useCallback(() => {
+    setViewMode(VIEW_MODE.List);
+    setSelectedSkill(null);
+  }, []);
+
+  const handleEdit = useCallback(() => {
+    setViewMode(VIEW_MODE.Edit);
+  }, []);
+
+  const handleEditDone = useCallback(() => {
+    setViewMode(VIEW_MODE.Detail);
+  }, []);
+
+  return {
+    skills: skillsQuery.data ?? [],
+    isLoading: skillsQuery.isLoading,
+    isError: skillsQuery.isError,
+    refetch: skillsQuery.refetch,
+    selectedSkill,
+    viewMode,
+    onSelectSkill: handleSelectSkill,
+    onBack: handleBack,
+    onEdit: handleEdit,
+    onEditDone: handleEditDone,
+    onUninstall: uninstallMutation.mutate,
+    isUninstalling: uninstallMutation.isPending,
+  };
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,3 +47,5 @@ tauri-plugin-window-state = "2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 notify = { version = "7", default-features = false, features = ["macos_fsevent"] }
 urlencoding = "2"
+serde_yaml = "0.9"
+which = "7"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod tools_commands;
 pub mod trends_commands;
 pub mod usage_commands;
 pub mod user_commands;
+pub mod skills_commands;
 pub mod wrapped_commands;
 
 pub use analytics_commands::*;
@@ -26,6 +27,7 @@ pub use tools_commands::*;
 pub use trends_commands::*;
 pub use usage_commands::*;
 pub use user_commands::*;
+pub use skills_commands::*;
 pub use wrapped_commands::*;
 
 /// Macro to generate the Tauri command handler with all registered commands
@@ -80,6 +82,14 @@ macro_rules! app_commands {
             commands::show_claude_login,
             commands::hide_claude_login,
             commands::logout_claude,
+            // Skills commands
+            commands::list_skills,
+            commands::get_skill_detail,
+            commands::update_skill,
+            commands::install_skill,
+            commands::uninstall_skill,
+            commands::enable_skill,
+            commands::disable_skill,
             // System commands
             commands::open_log_directory,
         ]

--- a/src-tauri/src/commands/skills_commands.rs
+++ b/src-tauri/src/commands/skills_commands.rs
@@ -1,0 +1,64 @@
+//! Skills commands
+//!
+//! Tauri IPC commands for managing Claude Code skills.
+
+use tauri::command;
+
+use crate::services::SkillsService;
+use crate::types::{SkillCommandResult, SkillDetail, SkillSummary};
+
+/// List all installed skills
+#[command]
+pub async fn list_skills() -> Result<Vec<SkillSummary>, String> {
+    SkillsService::list_skills()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Get detailed information about a specific skill
+#[command]
+pub async fn get_skill_detail(name: String) -> Result<SkillDetail, String> {
+    SkillsService::get_skill_detail(&name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Update a skill's SKILL.md content
+#[command]
+pub async fn update_skill(name: String, content: String) -> Result<SkillCommandResult, String> {
+    SkillsService::update_skill(&name, &content)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Install a skill via claude plugin CLI
+#[command]
+pub async fn install_skill(name: String) -> Result<SkillCommandResult, String> {
+    SkillsService::install_skill(&name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Uninstall a skill by removing its directory
+#[command]
+pub async fn uninstall_skill(path: String) -> Result<SkillCommandResult, String> {
+    SkillsService::uninstall_skill(&path)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Enable a skill via claude plugin CLI
+#[command]
+pub async fn enable_skill(name: String) -> Result<SkillCommandResult, String> {
+    SkillsService::enable_skill(&name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Disable a skill via claude plugin CLI
+#[command]
+pub async fn disable_skill(name: String) -> Result<SkillCommandResult, String> {
+    SkillsService::disable_skill(&name)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -15,6 +15,7 @@ pub mod time_range;
 mod tools_service;
 mod trends_service;
 mod usage_service;
+mod skills_service;
 mod wrapped_service;
 
 pub use analytics_service::AnalyticsService;
@@ -26,4 +27,5 @@ pub use subscription_usage_service::SubscriptionUsageService;
 pub use tools_service::ToolsService;
 pub use trends_service::TrendsService;
 pub use usage_service::UsageService;
+pub use skills_service::SkillsService;
 pub use wrapped_service::WrappedService;

--- a/src-tauri/src/services/skills_service.rs
+++ b/src-tauri/src/services/skills_service.rs
@@ -1,0 +1,263 @@
+//! Skills service
+//!
+//! Service for managing Claude Code skills from the filesystem.
+//! Skills are stored in ~/.claude/skills/ as directories containing SKILL.md files.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::types::{SkillCommandResult, SkillDetail, SkillSummary};
+
+/// YAML frontmatter from SKILL.md
+#[derive(Debug, Deserialize, Default)]
+struct SkillFrontmatter {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+/// Entry from .skills-manifest.json
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct ManifestEntry {
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    package_name: Option<String>,
+    #[serde(default)]
+    installed_at: Option<String>,
+}
+
+pub struct SkillsService;
+
+impl SkillsService {
+    fn get_skills_dir() -> Result<PathBuf> {
+        let home = dirs::home_dir().context("Failed to get home directory")?;
+        Ok(home.join(".claude").join("skills"))
+    }
+
+    fn read_manifest() -> HashMap<String, ManifestEntry> {
+        let Ok(skills_dir) = Self::get_skills_dir() else {
+            return HashMap::new();
+        };
+        let manifest_path = skills_dir.join(".skills-manifest.json");
+        fs::read_to_string(&manifest_path)
+            .ok()
+            .and_then(|content| serde_json::from_str(&content).ok())
+            .unwrap_or_default()
+    }
+
+    fn parse_frontmatter(content: &str) -> (SkillFrontmatter, String) {
+        let trimmed = content.trim_start();
+        if !trimmed.starts_with("---") {
+            return (SkillFrontmatter::default(), content.to_string());
+        }
+
+        // Find the closing ---
+        let after_first = &trimmed[3..];
+        if let Some(end_idx) = after_first.find("\n---") {
+            let yaml_str = &after_first[..end_idx].trim();
+            let body = &after_first[end_idx + 4..]; // skip \n---
+            let frontmatter: SkillFrontmatter =
+                serde_yaml::from_str(yaml_str).unwrap_or_default();
+            (frontmatter, body.trim_start_matches('\n').to_string())
+        } else {
+            (SkillFrontmatter::default(), content.to_string())
+        }
+    }
+
+    fn is_symlink(path: &Path) -> bool {
+        fs::symlink_metadata(path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+    }
+
+    pub async fn list_skills() -> Result<Vec<SkillSummary>> {
+        let skills_dir = Self::get_skills_dir()?;
+        if !skills_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let manifest = Self::read_manifest();
+        let mut skills = Vec::new();
+
+        let entries = fs::read_dir(&skills_dir).context("Failed to read skills directory")?;
+
+        for entry in entries.flatten() {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+
+            // Skip hidden files and manifest
+            if file_name.starts_with('.') {
+                continue;
+            }
+
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let skill_md_path = path.join("SKILL.md");
+            let is_symlink = Self::is_symlink(&path);
+
+            let (frontmatter, _body) = if skill_md_path.exists() {
+                let content = fs::read_to_string(&skill_md_path).unwrap_or_default();
+                Self::parse_frontmatter(&content)
+            } else {
+                (SkillFrontmatter::default(), String::new())
+            };
+
+            let manifest_entry = manifest.get(&file_name);
+
+            skills.push(SkillSummary {
+                name: frontmatter.name.unwrap_or_else(|| file_name.clone()),
+                description: frontmatter.description.unwrap_or_default(),
+                version: frontmatter.version.unwrap_or_else(|| "0.0.0".to_string()),
+                is_symlink,
+                source: manifest_entry.and_then(|e| e.source.clone()),
+                package_name: manifest_entry.and_then(|e| e.package_name.clone()),
+                installed_at: manifest_entry.and_then(|e| e.installed_at.clone()),
+                path: path.to_string_lossy().to_string(),
+            });
+        }
+
+        skills.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        Ok(skills)
+    }
+
+    pub async fn get_skill_detail(name: &str) -> Result<SkillDetail> {
+        let skills_dir = Self::get_skills_dir()?;
+        let skill_path = skills_dir.join(name);
+
+        if !skill_path.exists() || !skill_path.is_dir() {
+            anyhow::bail!("Skill '{}' not found", name);
+        }
+
+        let skill_md_path = skill_path.join("SKILL.md");
+        let raw_content = if skill_md_path.exists() {
+            fs::read_to_string(&skill_md_path).context("Failed to read SKILL.md")?
+        } else {
+            String::new()
+        };
+
+        let (frontmatter, markdown_body) = Self::parse_frontmatter(&raw_content);
+        let is_symlink = Self::is_symlink(&skill_path);
+        let manifest = Self::read_manifest();
+        let manifest_entry = manifest.get(name);
+
+        Ok(SkillDetail {
+            name: frontmatter.name.unwrap_or_else(|| name.to_string()),
+            description: frontmatter.description.unwrap_or_default(),
+            version: frontmatter.version.unwrap_or_else(|| "0.0.0".to_string()),
+            raw_content,
+            markdown_body,
+            is_symlink,
+            is_readonly: is_symlink,
+            source: manifest_entry.and_then(|e| e.source.clone()),
+            package_name: manifest_entry.and_then(|e| e.package_name.clone()),
+            installed_at: manifest_entry.and_then(|e| e.installed_at.clone()),
+            path: skill_path.to_string_lossy().to_string(),
+        })
+    }
+
+    pub async fn update_skill(name: &str, content: &str) -> Result<SkillCommandResult> {
+        let skills_dir = Self::get_skills_dir()?;
+        let skill_path = skills_dir.join(name);
+
+        if !skill_path.exists() || !skill_path.is_dir() {
+            return Ok(SkillCommandResult {
+                success: false,
+                message: format!("Skill '{}' not found", name),
+            });
+        }
+
+        if Self::is_symlink(&skill_path) {
+            return Ok(SkillCommandResult {
+                success: false,
+                message: "Cannot edit a symlinked skill. It is managed externally.".to_string(),
+            });
+        }
+
+        let skill_md_path = skill_path.join("SKILL.md");
+        fs::write(&skill_md_path, content).context("Failed to write SKILL.md")?;
+
+        Ok(SkillCommandResult {
+            success: true,
+            message: "Skill updated successfully".to_string(),
+        })
+    }
+
+    fn find_claude_binary() -> Result<PathBuf> {
+        which::which("claude").context(
+            "Claude CLI not found in PATH. Please install Claude Code first.",
+        )
+    }
+
+    async fn run_plugin_command(args: &[&str]) -> Result<SkillCommandResult> {
+        let claude_bin = Self::find_claude_binary()?;
+
+        let output = tokio::process::Command::new(&claude_bin)
+            .args(args)
+            .output()
+            .await
+            .context("Failed to execute claude command")?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        if output.status.success() {
+            Ok(SkillCommandResult {
+                success: true,
+                message: if stdout.trim().is_empty() {
+                    "Command completed successfully".to_string()
+                } else {
+                    stdout.trim().to_string()
+                },
+            })
+        } else {
+            Ok(SkillCommandResult {
+                success: false,
+                message: if stderr.trim().is_empty() {
+                    stdout.trim().to_string()
+                } else {
+                    stderr.trim().to_string()
+                },
+            })
+        }
+    }
+
+    pub async fn install_skill(name: &str) -> Result<SkillCommandResult> {
+        Self::run_plugin_command(&["plugin", "install", name]).await
+    }
+
+    pub async fn uninstall_skill(path: &str) -> Result<SkillCommandResult> {
+        let skill_path = std::path::Path::new(path);
+
+        if !skill_path.exists() || !skill_path.is_dir() {
+            return Ok(SkillCommandResult {
+                success: false,
+                message: format!("Skill path '{}' not found", path),
+            });
+        }
+
+        fs::remove_dir_all(skill_path).context("Failed to remove skill directory")?;
+
+        Ok(SkillCommandResult {
+            success: true,
+            message: "Skill removed successfully".to_string(),
+        })
+    }
+
+    pub async fn enable_skill(name: &str) -> Result<SkillCommandResult> {
+        Self::run_plugin_command(&["plugin", "enable", name]).await
+    }
+
+    pub async fn disable_skill(name: &str) -> Result<SkillCommandResult> {
+        Self::run_plugin_command(&["plugin", "disable", name]).await
+    }
+}

--- a/src-tauri/src/types/mod.rs
+++ b/src-tauri/src/types/mod.rs
@@ -11,6 +11,7 @@ mod subscription_usage;
 mod tools;
 mod trends;
 mod usage;
+mod skills;
 mod wrapped;
 
 pub use analytics::*;
@@ -22,4 +23,5 @@ pub use subscription_usage::*;
 pub use tools::*;
 pub use trends::*;
 pub use usage::*;
+pub use skills::*;
 pub use wrapped::*;

--- a/src-tauri/src/types/skills.rs
+++ b/src-tauri/src/types/skills.rs
@@ -1,0 +1,48 @@
+//! Skills types
+//!
+//! Types for the Claude Skills management feature.
+
+use serde::{Deserialize, Serialize};
+use typeshare::typeshare;
+
+/// Summary of a skill for list display
+#[typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillSummary {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+    pub is_symlink: bool,
+    pub source: Option<String>,
+    pub package_name: Option<String>,
+    pub installed_at: Option<String>,
+    pub path: String,
+}
+
+/// Full detail of a skill for viewing/editing
+#[typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillDetail {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+    pub raw_content: String,
+    pub markdown_body: String,
+    pub is_symlink: bool,
+    pub is_readonly: bool,
+    pub source: Option<String>,
+    pub package_name: Option<String>,
+    pub installed_at: Option<String>,
+    pub path: String,
+}
+
+/// Result of a skill command (install/uninstall/enable/disable)
+#[typeshare]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillCommandResult {
+    pub success: bool,
+    pub message: String,
+}


### PR DESCRIPTION
## Summary

- Add full-stack Skills management module for browsing, viewing, editing, and deleting Claude Code skills from `~/.claude/skills/`
- Extract shared `MarkdownViewer` component from session-detail for reuse
- Add "Skills" entry to sidebar navigation with Puzzle icon

## Changes

### Rust Backend
- **Types** (`src-tauri/src/types/skills.rs`): `SkillSummary`, `SkillDetail`, `SkillCommandResult` with typeshare
- **Service** (`src-tauri/src/services/skills_service.rs`): Filesystem-only service — scans skills directory, parses YAML frontmatter, reads `.skills-manifest.json`, supports direct folder deletion for uninstall
- **Commands** (`src-tauri/src/commands/skills_commands.rs`): 7 IPC commands (list, detail, update, install, uninstall, enable, disable)
- **Dependencies**: Added `serde_yaml`, `which`

### Frontend
- **Bridge** (`packages/ui/src/bridges/skills-bridge.ts`): Tauri invoke wrappers
- **Module** (`packages/ui/src/modules/skills/`): Full module with list/detail/edit view modes
  - Card grid with hover-to-show delete button
  - Markdown rendered detail view
  - Split-pane editor (source + live preview)
  - Install dialog (hidden for now, pending CLI stabilization)
- **Shared component** (`packages/ui/src/components/markdown-viewer/`): Extracted from session-detail
- **Sidebar**: Added Skills nav item between Usage and Wrapped

## Test Plan

- [ ] Navigate to Skills page via sidebar
- [ ] Verify installed skills display as card grid
- [ ] Click card to view skill detail with rendered markdown
- [ ] Click Edit to enter split-pane editor, modify and save
- [ ] Hover card to reveal delete button, click to remove skill
- [ ] Verify list refreshes after deletion
- [ ] Verify symlinked skills show link icon and are read-only