### PR TITLE
refactor: improve chart empty states with skeleton visuals

### DIFF
--- a/packages/ui/src/components/card-chart-empty/index.tsx
+++ b/packages/ui/src/components/card-chart-empty/index.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EChart, emptyChartOption } from "@/components/echarts";
+import { cn } from "@/lib/utils";
+
+interface CardChartEmptyProps {
+  title: string;
+  chartType?: "axis" | "pie";
+  height?: number;
+  className?: string;
+}
+
+export function CardChartEmpty({
+  title,
+  chartType = "axis",
+  height = 220,
+  className,
+}: CardChartEmptyProps) {
+  return (
+    <Card className={cn("gap-3 py-4", className)}>
+      <CardHeader className="px-4">
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">
+        <EChart option={emptyChartOption(chartType)} style={{ height }} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/echarts/index.tsx
+++ b/packages/ui/src/components/echarts/index.tsx
@@ -19,6 +19,7 @@ import {
   CalendarComponent,
   VisualMapComponent,
   RadarComponent,
+  GraphicComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type { EChartsOption } from "echarts";
@@ -38,6 +39,7 @@ echarts.use([
   CalendarComponent,
   VisualMapComponent,
   RadarComponent,
+  GraphicComponent,
   CanvasRenderer,
 ]);
 
@@ -64,6 +66,74 @@ export function resolveChartColor(cssVar: string): string {
 export function resolveChartColorAlpha(cssVar: string, alpha: number): string {
   const rgb = resolveChartColor(cssVar);
   return rgb.replace("rgb(", "rgba(").replace(")", `, ${alpha})`);
+}
+
+/**
+ * Returns an ECharts option that renders an empty chart skeleton.
+ *
+ * - `"axis"` (default): grid with dashed split lines and faint y-axis labels
+ * - `"pie"`: a faint gray donut ring
+ *
+ * Both variants show a centered "No data" label.
+ */
+export function emptyChartOption(
+  type: "axis" | "pie" = "axis",
+): EChartsOption {
+  const mutedColor = resolveChartColor("--muted-foreground");
+  const borderColor = resolveChartColorAlpha("--border", 0.4);
+
+  const noDataGraphic = {
+    type: "text" as const,
+    left: "center" as const,
+    top: "middle" as const,
+    style: {
+      text: "No data",
+      fontSize: 13,
+      fill: mutedColor,
+      opacity: 0.6,
+    },
+  };
+
+  if (type === "pie") {
+    return {
+      graphic: noDataGraphic,
+      series: [
+        {
+          type: "pie",
+          radius: ["40%", "70%"],
+          data: [{ value: 1, itemStyle: { color: borderColor } }],
+          label: { show: false },
+          emphasis: { disabled: true },
+          silent: true,
+        },
+      ],
+    };
+  }
+
+  return {
+    graphic: noDataGraphic,
+    grid: { top: 10, right: 10, bottom: 20, left: 40 },
+    xAxis: {
+      type: "value",
+      show: false,
+    },
+    yAxis: {
+      type: "value",
+      min: 0,
+      max: 100,
+      splitNumber: 4,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      splitLine: {
+        lineStyle: { color: borderColor, type: "dashed" },
+      },
+      axisLabel: {
+        color: mutedColor,
+        opacity: 0.4,
+      },
+    },
+    series: [],
+  };
 }
 
 interface EChartsProps {

--- a/packages/ui/src/modules/analytics/components/model-mix/index.tsx
+++ b/packages/ui/src/modules/analytics/components/model-mix/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor } from "@/components/echarts";
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { ModelMixProps } from "./types";
 import { fmt } from "@/lib/format";
@@ -34,8 +34,9 @@ export function ModelMix({ timeRange }: ModelMixProps) {
         onRetry={() => refetch()}
       />
     );
-  if (data.length === 0)
-    return <CardEmpty title="Model Mix" message="No model data" />;
+  if (data.length === 0) {
+    return <CardChartEmpty title="Model Mix" chartType="pie" className="h-full" />;
+  }
 
   const option: EChartsOption = {
     tooltip: {

--- a/packages/ui/src/modules/analytics/components/session-length-chart/index.tsx
+++ b/packages/ui/src/modules/analytics/components/session-length-chart/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor, resolveChartColorAlpha } from "@/components/
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { SessionLengthChartProps } from "./types";
 
@@ -28,7 +28,7 @@ export function SessionLengthChart({ timeRange }: SessionLengthChartProps) {
     );
   }
   if (data.length === 0 || data.every((d) => d.count === 0)) {
-    return <CardEmpty title="Session Length" message="No session data" />;
+    return <CardChartEmpty title="Session Length Distribution" />;
   }
 
   const option: EChartsOption = {

--- a/packages/ui/src/modules/analytics/components/token-model-chart/index.tsx
+++ b/packages/ui/src/modules/analytics/components/token-model-chart/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor } from "@/components/echarts";
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { TokenModelChartProps } from "./types";
 
@@ -26,8 +26,9 @@ export function TokenModelChart({ timeRange }: TokenModelChartProps) {
         onRetry={() => refetch()}
       />
     );
-  if (data.length === 0)
-    return <CardEmpty title="Token Usage by Model" message="No token data" />;
+  if (data.length === 0) {
+    return <CardChartEmpty title="Token Usage by Model" height={160} />;
+  }
 
   const models = data.map((d) => d.displayName || d.model);
 

--- a/packages/ui/src/modules/overview/components/activity-heatmap/index.tsx
+++ b/packages/ui/src/modules/overview/components/activity-heatmap/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/tooltip";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
 import { useService } from "./use-service";
 
 const ROWS = 7;
@@ -174,10 +173,6 @@ export function ActivityHeatmap() {
       />
     );
   }
-  if (data.length === 0) {
-    return <CardEmpty title="Activity" message="No activity data yet" />;
-  }
-
   const cellMap = new Map<string, (typeof visibleCells)[0]>();
   for (const c of visibleCells) {
     cellMap.set(`${c.col}-${c.row}`, c);

--- a/packages/ui/src/modules/overview/components/cost-chart/index.tsx
+++ b/packages/ui/src/modules/overview/components/cost-chart/index.tsx
@@ -11,7 +11,7 @@ import { EChart, resolveChartColor } from "@/components/echarts";
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { CostChartProps } from "./types";
 import { TimeRange } from "@/generated/typeshare-types";
@@ -45,13 +45,7 @@ export function CostChart({ timeRange }: CostChartProps) {
   }
 
   if (dates.length === 0) {
-    return (
-      <CardEmpty
-        title="Cost Trends"
-        message="No cost data available"
-        className="h-full"
-      />
-    );
+    return <CardChartEmpty title="Cost Trends" height={250} className="h-full" />;
   }
 
   const mutedColor = resolveChartColor("--muted-foreground");

--- a/packages/ui/src/modules/tools/components/code-edit-decisions/index.tsx
+++ b/packages/ui/src/modules/tools/components/code-edit-decisions/index.tsx
@@ -11,7 +11,7 @@ import { EChart, resolveChartColor } from "@/components/echarts";
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { CodeEditDecisionsProps } from "./types";
 
@@ -28,8 +28,9 @@ export function CodeEditDecisions({ timeRange }: CodeEditDecisionsProps) {
         onRetry={() => refetch()}
       />
     );
-  if (totalAccepts + totalRejects === 0)
-    return <CardEmpty title="Code Edit Decisions" message="No data" />;
+  if (totalAccepts + totalRejects === 0) {
+    return <CardChartEmpty title="Code Edit Decisions" chartType="pie" height={200} />;
+  }
 
   const donutOption: EChartsOption = {
     tooltip: { trigger: "item", borderColor: "transparent" },

--- a/packages/ui/src/modules/tools/components/tool-duration/index.tsx
+++ b/packages/ui/src/modules/tools/components/tool-duration/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor, resolveChartColorAlpha } from "@/components/
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { ToolDurationProps } from "./types";
 
@@ -26,8 +26,9 @@ export function ToolDuration({ timeRange }: ToolDurationProps) {
         onRetry={() => refetch()}
       />
     );
-  if (data.length === 0)
-    return <CardEmpty title="Avg Duration" message="No data" />;
+  if (data.length === 0) {
+    return <CardChartEmpty title="Avg Duration" height={200} />;
+  }
 
   const option: EChartsOption = {
     tooltip: {

--- a/packages/ui/src/modules/tools/components/tool-frequency-bar/index.tsx
+++ b/packages/ui/src/modules/tools/components/tool-frequency-bar/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor, resolveChartColorAlpha } from "@/components/
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { ToolFrequencyBarProps } from "./types";
 
@@ -26,8 +26,9 @@ export function ToolFrequencyBar({ timeRange }: ToolFrequencyBarProps) {
         onRetry={() => refetch()}
       />
     );
-  if (data.length === 0)
-    return <CardEmpty title="Tool Usage" message="No tool data" />;
+  if (data.length === 0) {
+    return <CardChartEmpty title="Tool Usage (Top 10)" />;
+  }
 
   const sorted = [...data].sort((a, b) => b.count - a.count);
   const top = sorted.slice(0, 10);

--- a/packages/ui/src/modules/tools/components/tool-success-rate/index.tsx
+++ b/packages/ui/src/modules/tools/components/tool-success-rate/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor, resolveChartColorAlpha } from "@/components/
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { useService } from "./use-service";
 import type { ToolSuccessRateProps } from "./types";
 
@@ -26,8 +26,9 @@ export function ToolSuccessRate({ timeRange }: ToolSuccessRateProps) {
         onRetry={() => refetch()}
       />
     );
-  if (data.length === 0)
-    return <CardEmpty title="Success Rate" message="No data" />;
+  if (data.length === 0) {
+    return <CardChartEmpty title="Success Rate" height={200} />;
+  }
 
   const option: EChartsOption = {
     tooltip: {

--- a/packages/ui/src/modules/tools/components/tool-timeline/index.tsx
+++ b/packages/ui/src/modules/tools/components/tool-timeline/index.tsx
@@ -10,7 +10,7 @@ import { EChart, resolveChartColor, resolveChartColorAlpha } from "@/components/
 import type { EChartsOption } from "@/components/echarts";
 import { CardLoading } from "@/components/card-loading";
 import { CardError } from "@/components/card-error";
-import { CardEmpty } from "@/components/card-empty";
+import { CardChartEmpty } from "@/components/card-chart-empty";
 import { TimeRange } from "@/generated/typeshare-types";
 import { useService } from "./use-service";
 import type { ToolTimelineProps } from "./types";
@@ -34,8 +34,9 @@ export function ToolTimeline({ timeRange }: ToolTimelineProps) {
         onRetry={() => refetch()}
       />
     );
-  if (series.length === 0)
-    return <CardEmpty title="Tool Timeline" message="No data" />;
+  if (series.length === 0) {
+    return <CardChartEmpty title="Tool Timeline (Top 5)" height={250} />;
+  }
 
   const option: EChartsOption = {
     tooltip: { trigger: "axis", borderColor: "transparent" },

--- a/packages/ui/src/modules/wrapped/index.tsx
+++ b/packages/ui/src/modules/wrapped/index.tsx
@@ -100,7 +100,7 @@ export function Wrapped() {
           )}
           {data && hasMeaningfulData && (
             <div ref={cardRef} className="bg-muted p-10">
-              <div className="w-full max-w-md rounded-xl border border-border bg-card py-6">
+              <div className="w-md rounded-xl border border-border bg-card py-6">
                 <div className="px-6 pb-2">
                   <p className="text-center text-xs uppercase tracking-widest text-muted-foreground">
                     Your Claude Code Wrapped

--- a/src-tauri/src/services/wrapped_service.rs
+++ b/src-tauri/src/services/wrapped_service.rs
@@ -364,10 +364,13 @@ impl WrappedService {
 
         let start = match period {
             WrappedPeriod::Today => now.date_naive().and_hms_opt(0, 0, 0).unwrap(),
-            WrappedPeriod::Week => (now - chrono::Duration::days(7))
-                .date_naive()
-                .and_hms_opt(0, 0, 0)
-                .unwrap(),
+            WrappedPeriod::Week => {
+                let days_since_monday = now.weekday().num_days_from_monday() as i64;
+                (now - chrono::Duration::days(days_since_monday))
+                    .date_naive()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+            }
             WrappedPeriod::Month => now
                 .date_naive()
                 .with_day(1)


### PR DESCRIPTION
## Summary
- Add `CardChartEmpty` reusable component for chart empty states — renders axis grid skeleton (bar/line) or faint donut ring (pie) instead of plain "No data" text
- Add `emptyChartOption` utility to EChart component with `"axis"` and `"pie"` variants
- Fix wrapped card width jitter when switching periods (`w-full max-w-md` → `w-md`)
- Unify `WrappedPeriod::Week` to use natural calendar week (Monday–today) matching `TimeRange::Week`

## Test plan
- [ ] Switch to Today/Week/Month on Overview, Tools, Analytics pages — empty charts show skeleton grid instead of blank
- [ ] Verify pie chart empty states (Model Mix, Code Edit Decisions) show faint donut ring
- [ ] Verify Wrapped card width stays fixed when switching between periods
- [ ] Verify Wrapped Week period now starts from Monday (not rolling 7 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)