### PR TITLE
fix: resolve skills plugin install mutation type error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2670,7 +2670,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumo-daemon"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/packages/ui/src/modules/skills/components/add-skill-dialog/use-service.ts
+++ b/packages/ui/src/modules/skills/components/add-skill-dialog/use-service.ts
@@ -64,7 +64,7 @@ export function useService(onClose: () => void) {
   });
 
   const pluginInstallMutation = useMutation({
-    mutationFn: SkillsBridge.installSkill,
+    mutationFn: (name: string) => SkillsBridge.installSkill(name),
     onSuccess: (result) => {
       if (result.success) {
         setPluginName("");


### PR DESCRIPTION
## Summary
- Fix `mutationFn` type mismatch in skills add-skill-dialog by wrapping `SkillsBridge.installSkill` in an arrow function, preventing TanStack Query from passing mutation context as the `projectPath` parameter
- Sync `Cargo.lock` with v0.2.0 version bump

## Test plan
- [ ] Verify skills plugin install works correctly from the add-skill dialog
- [ ] Verify `pnpm build` passes without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)