### PR TITLE
fix: wrap batch inserts in transaction to reduce CPU usage

### DIFF
--- a/crates/shared/src/database/repositories/event_repo.rs
+++ b/crates/shared/src/database/repositories/event_repo.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides CRUD operations for events.
 
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqlitePool};
 
 use crate::database::entities::{Event, EventRow, NewEvent};
 use crate::error::Result;
@@ -11,8 +11,11 @@ use crate::error::Result;
 pub struct EventRepository;
 
 impl EventRepository {
-    /// Insert a new event
-    pub async fn insert(pool: &SqlitePool, event: &NewEvent) -> Result<()> {
+    /// Insert a new event into any executor (pool or transaction)
+    pub async fn insert<'e, E>(executor: E, event: &NewEvent) -> Result<()>
+    where
+        E: sqlx::Executor<'e, Database = Sqlite>,
+    {
         sqlx::query(
             r#"
             INSERT INTO events (
@@ -68,17 +71,25 @@ impl EventRepository {
         .bind(&event.user_email)
         .bind(event.event_sequence)
         .bind(event.tool_result_size_bytes)
-        .execute(pool)
+        .execute(executor)
         .await?;
 
         Ok(())
     }
 
-    /// Insert multiple events in a batch
+    /// Insert multiple events in a batch using a single transaction
     pub async fn insert_batch(pool: &SqlitePool, events: &[NewEvent]) -> Result<()> {
-        for event in events {
-            Self::insert(pool, event).await?;
+        if events.is_empty() {
+            return Ok(());
         }
+
+        let mut tx = pool.begin().await?;
+
+        for event in events {
+            Self::insert(&mut *tx, event).await?;
+        }
+
+        tx.commit().await?;
         Ok(())
     }
 

--- a/crates/shared/src/database/repositories/metric_repo.rs
+++ b/crates/shared/src/database/repositories/metric_repo.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides CRUD operations for metrics.
 
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqlitePool};
 
 use crate::database::entities::{Metric, MetricRow, NewMetric};
 use crate::error::Result;
@@ -11,8 +11,11 @@ use crate::error::Result;
 pub struct MetricRepository;
 
 impl MetricRepository {
-    /// Insert a new metric
-    pub async fn insert(pool: &SqlitePool, metric: &NewMetric) -> Result<()> {
+    /// Insert a new metric into any executor (pool or transaction)
+    pub async fn insert<'e, E>(executor: E, metric: &NewMetric) -> Result<()>
+    where
+        E: sqlx::Executor<'e, Database = Sqlite>,
+    {
         sqlx::query(
             r#"
             INSERT INTO metrics (
@@ -49,17 +52,25 @@ impl MetricRepository {
         .bind(&metric.user_email)
         .bind(&metric.unit)
         .bind(&metric.description)
-        .execute(pool)
+        .execute(executor)
         .await?;
 
         Ok(())
     }
 
-    /// Insert multiple metrics in a batch
+    /// Insert multiple metrics in a batch using a single transaction
     pub async fn insert_batch(pool: &SqlitePool, metrics: &[NewMetric]) -> Result<()> {
-        for metric in metrics {
-            Self::insert(pool, metric).await?;
+        if metrics.is_empty() {
+            return Ok(());
         }
+
+        let mut tx = pool.begin().await?;
+
+        for metric in metrics {
+            Self::insert(&mut *tx, metric).await?;
+        }
+
+        tx.commit().await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Wrapped `insert_batch` in `EventRepository` and `MetricRepository` with an explicit transaction, reducing N fsyncs per batch to 1
- Generalized `insert()` to accept generic `sqlx::Executor`, so the same SQL is reused by both single and batch inserts
- Added early return for empty input in `insert_batch`

## Context
The daemon was consuming 85% CPU. Root cause was orphaned migration records causing crash-restart loops every 10s, compounded by each `insert_batch` call executing N independent auto-commit transactions (one fsync per record).

## Test plan
- [x] `cargo check -p shared -p lumo-daemon` passes
- [x] Deployed to local daemon, confirmed CPU dropped to 0.0%
- [x] Verified OTLP data ingestion works correctly after change

🤖 Generated with [Claude Code](https://claude.com/claude-code)