### PR TITLE
fix: resolve multiple UI issues (#23)

### DIFF
--- a/packages/ui/app/globals.css
+++ b/packages/ui/app/globals.css
@@ -143,3 +143,8 @@
   height: 100%;
   overflow: hidden;
 }
+
+/* Mobile sidebar (Sheet) — offset for macOS traffic light buttons */
+[data-slot="sidebar"][data-mobile="true"] > div:last-of-type {
+  padding-top: var(--titlebar-height);
+}

--- a/packages/ui/src/components/page-header/index.tsx
+++ b/packages/ui/src/components/page-header/index.tsx
@@ -20,20 +20,20 @@ export function PageHeader({ title, children }: PageHeaderProps) {
 
   return (
     <header className="sticky top-0 z-10 flex h-12 shrink-0 items-center justify-between border-b bg-background/80 px-4 backdrop-blur-sm">
-      <div className="flex items-center gap-3">
-        <SidebarTrigger className="size-8" />
-        <div className="flex items-center gap-2">
-          <h1 className="text-sm font-semibold">{title}</h1>
-          <Badge variant="outline" className="gap-1 font-normal">
+      <div className="flex min-w-0 items-center gap-3">
+        <SidebarTrigger className="size-8 shrink-0" />
+        <div className="flex min-w-0 items-center gap-2">
+          <h1 className="truncate text-sm font-semibold">{title}</h1>
+          <Badge variant="outline" className="shrink-0 gap-1 font-normal">
             <Circle
               className={`size-2 fill-current ${STATUS_CONFIG[daemonStatus].color}`}
             />
-            {STATUS_CONFIG[daemonStatus].label}
+            <span className="hidden sm:inline">{STATUS_CONFIG[daemonStatus].label}</span>
           </Badge>
         </div>
       </div>
 
-      <div className="flex items-center gap-2">{children}</div>
+      <div className="flex shrink-0 items-center gap-2">{children}</div>
     </header>
   );
 }

--- a/packages/ui/src/components/project-nav/index.tsx
+++ b/packages/ui/src/components/project-nav/index.tsx
@@ -2,7 +2,6 @@
 
 import { FolderOpen, Layers } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import type { ProjectNavProps } from "./types";
 
@@ -23,9 +22,13 @@ function formatTimeAgo(timestamp: string): string {
   return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
-function truncatePath(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength - 3)}...`;
+function abbreviatePath(fullPath: string): string {
+  const home = "/Users/";
+  if (fullPath.startsWith(home)) {
+    const afterHome = fullPath.slice(home.length);
+    return `~/${afterHome.slice(afterHome.indexOf("/") + 1)}`;
+  }
+  return fullPath;
 }
 
 export function ProjectNav({
@@ -49,70 +52,68 @@ export function ProjectNav({
   return (
     <div
       className={cn(
-        "sticky top-0 z-20 w-full border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/80 md:static md:z-auto md:border-r md:border-b-0 md:bg-muted/20 md:backdrop-blur-0",
+        "sticky top-0 z-20 w-full border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/80 md:static md:z-auto md:shrink-0 md:overflow-hidden md:border-r md:border-b-0 md:bg-muted/20 md:backdrop-blur-0",
         widthClass,
       )}
     >
-      {/* Mobile: horizontal scroll pills */}
+      {/* Mobile: wrapped pills */}
       <div className="border-b px-3 py-2 md:hidden">
-        <ScrollArea className="w-full whitespace-nowrap">
-          <div className="flex gap-2 pb-1">
-            <button
-              className={cn(
-                "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-accent",
-                selected === null
-                  ? "border-primary/40 bg-accent"
-                  : "border-border bg-background",
-              )}
-              onClick={() => onSelect(null)}
-              type="button"
-            >
-              {AllIcon}
-              <span className="font-medium">{allLabel}</span>
-              {allBadge != null && (
-                <Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
-                  {allBadge}
-                </Badge>
-              )}
-            </button>
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            className={cn(
+              "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-accent",
+              selected === null
+                ? "border-primary/40 bg-accent"
+                : "border-border bg-background",
+            )}
+            onClick={() => onSelect(null)}
+            type="button"
+          >
+            {AllIcon}
+            <span className="font-medium">{allLabel}</span>
+            {allBadge != null && (
+              <Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
+                {allBadge}
+              </Badge>
+            )}
+          </button>
 
-            {projects.map((project) => {
-              const isActive = selected === project.projectPath;
-              const count = counts?.[project.projectPath];
-              return (
-                <button
-                  key={project.projectPath}
-                  className={cn(
-                    "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-accent",
-                    isActive
-                      ? "border-primary/40 bg-accent"
-                      : "border-border bg-background",
-                  )}
-                  onClick={() => onSelect(project.projectPath)}
-                  type="button"
-                  title={project.projectPath}
-                >
-                  <FolderOpen className="size-3.5 text-muted-foreground" />
-                  <span className="max-w-28 truncate font-medium">
-                    {project.projectName}
-                  </span>
-                  {count != null && (
-                    <Badge
-                      variant="secondary"
-                      className="h-4 px-1.5 text-[10px]"
-                    >
-                      {count}
-                    </Badge>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        </ScrollArea>
+          {projects.map((project) => {
+            const isActive = selected === project.projectPath;
+            const count = counts?.[project.projectPath];
+            return (
+              <button
+                key={project.projectPath}
+                className={cn(
+                  "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors hover:bg-accent",
+                  isActive
+                    ? "border-primary/40 bg-accent"
+                    : "border-border bg-background",
+                )}
+                onClick={() => onSelect(project.projectPath)}
+                type="button"
+                title={project.projectPath}
+              >
+                <FolderOpen className="size-3.5 text-muted-foreground" />
+                <span className="max-w-28 truncate font-medium">
+                  {project.projectName}
+                </span>
+                {count != null && (
+                  <Badge
+                    variant="secondary"
+                    className="h-4 px-1.5 text-[10px]"
+                  >
+                    {count}
+                  </Badge>
+                )}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       {/* Desktop: vertical sidebar */}
-      <div className="hidden md:block">
+      <div className="hidden overflow-hidden md:block">
         <div className="border-b px-3 py-2">
           <button
             className={cn(
@@ -130,7 +131,7 @@ export function ProjectNav({
           </button>
         </div>
 
-        <ScrollArea className="h-[calc(100%-49px)]">
+        <div className="h-[calc(100%-49px)] overflow-y-auto">
           <div className="space-y-1 p-2">
             {projects.length === 0 && (
               <p className="px-2 py-3 text-xs text-muted-foreground">
@@ -144,14 +145,13 @@ export function ProjectNav({
                 <button
                   key={project.projectPath}
                   className={cn(
-                    "w-full rounded-md border px-2 py-2 text-left transition-colors hover:bg-accent/60",
+                    "w-full min-w-0 rounded-md border px-2 py-2 text-left transition-colors hover:bg-accent/60",
                     isActive
                       ? "border-primary/40 bg-accent"
                       : "border-transparent",
                   )}
                   onClick={() => onSelect(project.projectPath)}
                   type="button"
-                  title={project.projectPath}
                 >
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex min-w-0 items-center gap-2">
@@ -169,8 +169,11 @@ export function ProjectNav({
 
                   {showDetails && (
                     <>
-                      <p className="mt-1 truncate text-xs text-muted-foreground">
-                        {truncatePath(project.projectPath, 56)}
+                      <p
+                        className="mt-1 truncate text-xs text-muted-foreground"
+                        title={project.projectPath}
+                      >
+                        {abbreviatePath(project.projectPath)}
                       </p>
                       <p className="mt-1 text-xs text-muted-foreground">
                         {formatTimeAgo(project.lastUpdated)}
@@ -181,7 +184,7 @@ export function ProjectNav({
               );
             })}
           </div>
-        </ScrollArea>
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/modules/marketplace/components/plugin-card/index.tsx
+++ b/packages/ui/src/modules/marketplace/components/plugin-card/index.tsx
@@ -49,7 +49,7 @@ export function PluginCard({
       onClick={() => onSelect(plugin)}
     >
       <CardHeader className="px-4">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <CardTitle className="truncate text-sm">{plugin.name}</CardTitle>

--- a/packages/ui/src/modules/wrapped/components/hero-stat/index.tsx
+++ b/packages/ui/src/modules/wrapped/components/hero-stat/index.tsx
@@ -20,7 +20,7 @@ export function HeroStat({ data }: { data: WrappedData }) {
         You&apos;ve collaborated with Claude for
       </p>
       <div className="flex items-baseline gap-2">
-        <span className="text-5xl font-extrabold tabular-nums bg-gradient-to-r from-chart-1 to-chart-2 bg-clip-text text-transparent">
+        <span className="text-4xl font-extrabold tabular-nums bg-gradient-to-r from-chart-1 to-chart-2 bg-clip-text text-transparent sm:text-5xl">
           {time.value}
         </span>
         <span className="text-xl font-medium text-muted-foreground">

--- a/packages/ui/src/modules/wrapped/index.tsx
+++ b/packages/ui/src/modules/wrapped/index.tsx
@@ -99,8 +99,8 @@ export function Wrapped() {
             />
           )}
           {data && hasMeaningfulData && (
-            <div ref={cardRef} className="bg-muted p-10">
-              <div className="w-md rounded-xl border border-border bg-card py-6">
+            <div ref={cardRef} className="w-full max-w-md bg-muted p-4 sm:p-10">
+              <div className="w-full rounded-xl border border-border bg-card py-6">
                 <div className="px-6 pb-2">
                   <p className="text-center text-xs uppercase tracking-widest text-muted-foreground">
                     Your Claude Code Wrapped

--- a/src-tauri/src/services/subscription_usage_service.rs
+++ b/src-tauri/src/services/subscription_usage_service.rs
@@ -39,7 +39,7 @@ fn build_extraction_js(request_id: &str) -> String {
     if (window.__LUMO_EXTRACT_ID === REQUEST_ID) return;
     window.__LUMO_EXTRACT_ID = REQUEST_ID;
     var attempts = 0;
-    var maxAttempts = 30;
+    var maxAttempts = 120;
 
     function emit(tag, payload) {{
         window.location.hash = tag + ':' + REQUEST_ID + ':' + encodeURIComponent(JSON.stringify(payload));
@@ -189,16 +189,25 @@ pub struct SubscriptionUsageService;
 impl SubscriptionUsageService {
     /// Fetch subscription usage by navigating a hidden webview to claude.ai/settings/usage.
     pub async fn fetch_usage(app_handle: &AppHandle) -> Result<SubscriptionUsageResult> {
+        // Check if webview already exists and is on the usage page (skip navigation wait)
+        let already_on_usage = app_handle
+            .get_webview_window(WEBVIEW_LABEL)
+            .and_then(|w| w.url().ok())
+            .map(|u| u.as_str().starts_with(USAGE_URL))
+            .unwrap_or(false);
+
         let webview = Self::get_or_create_webview(app_handle, USAGE_URL)?;
 
         // Ensure webview is hidden (may still be visible from a previous login flow)
         let _ = webview.hide();
 
-        // Wait for navigation, polling URL until it settles (up to 5s)
-        let target_settled = Self::wait_for_navigation(&webview, 10).await;
+        // Only wait for navigation if we actually navigated to a new page
+        if !already_on_usage {
+            let target_settled = Self::wait_for_navigation(&webview, 10).await;
 
-        if !target_settled {
-            log::warn!("Navigation did not settle within timeout, proceeding anyway");
+            if !target_settled {
+                log::warn!("Navigation did not settle within timeout, proceeding anyway");
+            }
         }
 
         // Check if we got redirected to login (unified check)
@@ -233,9 +242,26 @@ impl SubscriptionUsageService {
         // Re-inject the extraction script periodically in case the initial
         // injection was lost during page navigation (the script guards against
         // duplicate execution via window.__LUMO_EXTRACT_ID).
+        // Timeout: 3 minutes (360 × 500ms). UI shows loading during this time.
         let mut last_inject = std::time::Instant::now();
-        for i in 0..40 {
+        for i in 0..360 {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+            let url = webview.url().context("Failed to get webview URL")?;
+            let url_str = url.as_str();
+
+            // Detect network errors early: webview stuck on blank/error page
+            if i == 20 {
+                // After 10s, if URL is still blank or an error page, network is likely down
+                if url_str == "about:blank" || url_str.starts_with("about:") {
+                    return Ok(SubscriptionUsageResult {
+                        needs_login: false,
+                        usage: None,
+                        error: Some("Unable to connect to claude.ai. Please check your network connection.".to_string()),
+                        parse_error: false,
+                    });
+                }
+            }
 
             // Re-inject every ~5s if no result yet
             if i > 0 && last_inject.elapsed() > std::time::Duration::from_secs(5) {
@@ -246,7 +272,6 @@ impl SubscriptionUsageService {
                 last_inject = std::time::Instant::now();
             }
 
-            let url = webview.url().context("Failed to get webview URL")?;
             let fragment = url.fragment().unwrap_or("");
 
             // Expected format: TAG:REQUEST_ID:ENCODED_JSON
@@ -299,7 +324,7 @@ impl SubscriptionUsageService {
         Ok(SubscriptionUsageResult {
             needs_login: false,
             usage: None,
-            error: Some("Timed out waiting for usage data extraction".to_string()),
+            error: Some("Unable to load usage data. Please try again later.".to_string()),
             parse_error: false,
         })
     }
@@ -376,11 +401,18 @@ impl SubscriptionUsageService {
 
     fn get_or_create_webview(app_handle: &AppHandle, url: &str) -> Result<tauri::WebviewWindow> {
         if let Some(existing) = app_handle.get_webview_window(WEBVIEW_LABEL) {
-            // Use native navigate() instead of eval-based navigation
-            let parsed: tauri::Url = url.parse().context("Invalid URL")?;
-            existing
-                .navigate(parsed)
-                .context("Failed to navigate existing webview")?;
+            // Skip navigation if already on the target page (avoids full reload)
+            let already_there = existing
+                .url()
+                .map(|u| u.as_str().starts_with(url))
+                .unwrap_or(false);
+
+            if !already_there {
+                let parsed: tauri::Url = url.parse().context("Invalid URL")?;
+                existing
+                    .navigate(parsed)
+                    .context("Failed to navigate existing webview")?;
+            }
             return Ok(existing);
         }
 


### PR DESCRIPTION
## Summary
- **ProjectNav**: Fix path overflow by replacing Radix ScrollArea (whose `display:table` viewport broke width constraints) with plain `overflow-y-auto`, abbreviate paths with `~/` prefix, show full path on hover via `title`
- **ProjectNav mobile**: Switch from horizontal ScrollArea to `flex-wrap` so all project pills are visible
- **Marketplace**: Add `flex-wrap` to plugin card header preventing install button overflow at narrow widths
- **PageHeader**: Add `truncate`/`min-w-0` to prevent title overflow, hide daemon badge text on narrow screens
- **Mobile sidebar**: Add `padding-top` offset for macOS traffic light buttons when sidebar is in Sheet mode
- **Wrapped**: Fix card width (`w-md` → `w-full max-w-md`), responsive padding and hero stat text size
- **Usage service**: Increase extraction timeout from 20s to 3min with early network error detection, improve error messages, skip redundant navigation when webview already on usage page

## Test plan
- [ ] Resize window to narrow width, verify ProjectNav paths truncate with ellipsis and show full path on hover
- [ ] At small window (< 768px), verify project pills wrap and are all visible
- [ ] Verify marketplace plugin cards don't overflow at narrow widths
- [ ] Verify page header title truncates gracefully at narrow widths
- [ ] At small window, open sidebar (Sheet mode) and verify content is below macOS traffic lights
- [ ] Open Wrapped page at narrow width, verify card doesn't overflow
- [ ] Open Usage page, verify loading state shows while fetching

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)