### PR TITLE
chore: upgrade CI artifact actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,7 @@ jobs:
             src-tauri/src crates/shared/src
 
       - name: Upload generated types
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: typeshare-types
           path: packages/ui/src/generated/typeshare-types.ts
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download generated types
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: typeshare-types
           path: packages/ui/src/generated


### PR DESCRIPTION
## Summary

- Upgrade `actions/upload-artifact` from v4 to v7
- Upgrade `actions/download-artifact` from v4 to v8

No breaking changes for our usage (basic `name`/`path`/`retention-days` parameters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)