### PR TITLE
fix: add Linux systemd support for daemon management

### DIFF
--- a/src-tauri/resources/com.lumo.daemon.service.template
+++ b/src-tauri/resources/com.lumo.daemon.service.template
@@ -1,0 +1,17 @@
+[Unit]
+Description=Lumo Daemon - Claude Code telemetry receiver
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{DAEMON_PATH}}
+Environment=HOME={{HOME}}
+WorkingDirectory={{HOME}}
+Restart=on-failure
+RestartSec=10
+Nice=5
+StandardOutput=append:{{LOG_DIR}}/stdout.log
+StandardError=append:{{LOG_DIR}}/stderr.log
+
+[Install]
+WantedBy=default.target

--- a/src-tauri/src/daemon/manager.rs
+++ b/src-tauri/src/daemon/manager.rs
@@ -1,11 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tauri::Manager;
 
 use super::health::check_daemon_health;
-use super::plist;
 
 /// Expected daemon version — read from crates/daemon/Cargo.toml at compile time.
 const EXPECTED_VERSION: &str = env!("DAEMON_VERSION");
@@ -16,9 +15,13 @@ const DAEMON_BINARY: &str = "lumo-daemon";
 pub struct DaemonManager {
     /// ~/.lumo/bin/lumo-daemon
     binary_path: PathBuf,
-    /// ~/Library/LaunchAgents/com.lumo.daemon.plist
-    plist_path: PathBuf,
-    /// ~/Library/Logs/com.lumo.daemon/
+    /// Platform-specific service file path:
+    /// - macOS: ~/Library/LaunchAgents/com.lumo.daemon.plist
+    /// - Linux: ~/.config/systemd/user/lumo-daemon.service
+    service_file_path: PathBuf,
+    /// Platform-specific log directory:
+    /// - macOS: ~/Library/Logs/com.lumo.daemon/
+    /// - Linux: ~/.lumo/logs/
     log_dir: PathBuf,
     /// User home directory
     home_dir: PathBuf,
@@ -31,19 +34,46 @@ impl DaemonManager {
         let home_dir = dirs::home_dir().context("Could not determine home directory")?;
 
         let binary_path = home_dir.join(".lumo/bin").join(DAEMON_BINARY);
-        let plist_path = home_dir
-            .join("Library/LaunchAgents")
-            .join("com.lumo.daemon.plist");
-        let log_dir = home_dir.join("Library/Logs/com.lumo.daemon");
+
+        let (service_file_path, log_dir) = Self::platform_paths(&home_dir);
+
         let source_binary = Self::resolve_source_binary(app_handle)?;
 
         Ok(Self {
             binary_path,
-            plist_path,
+            service_file_path,
             log_dir,
             home_dir,
             source_binary,
         })
+    }
+
+    /// Return platform-specific (service_file_path, log_dir).
+    fn platform_paths(home_dir: &Path) -> (PathBuf, PathBuf) {
+        #[cfg(target_os = "macos")]
+        {
+            let service_file_path = home_dir
+                .join("Library/LaunchAgents")
+                .join("com.lumo.daemon.plist");
+            let log_dir = home_dir.join("Library/Logs/com.lumo.daemon");
+            (service_file_path, log_dir)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let service_file_path = home_dir
+                .join(".config/systemd/user")
+                .join("lumo-daemon.service");
+            let log_dir = home_dir.join(".lumo/logs");
+            (service_file_path, log_dir)
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let service_file_path = home_dir.join(".lumo").join("daemon.json");
+            let log_dir = home_dir.join(".lumo/logs");
+            (service_file_path, log_dir)
+        }
     }
 
     /// Main entry point: ensure the daemon is installed and running with the
@@ -68,8 +98,8 @@ impl DaemonManager {
         if self.binary_path.exists() && self.is_executable() {
             // Binary exists but service is not running — try to load.
             log::info!("Daemon binary found but not running. Starting...");
-            self.install_plist()?;
-            plist::load_service(&self.plist_path).await?;
+            self.install_service_file()?;
+            Self::start_service(&self.service_file_path).await?;
             return self.wait_for_health().await;
         }
 
@@ -78,7 +108,7 @@ impl DaemonManager {
         self.install().await
     }
 
-    /// Full install: copy binary, create plist, start service.
+    /// Full install: copy binary, create service file, start service.
     async fn install(&self) -> Result<()> {
         self.do_install().await
     }
@@ -86,23 +116,23 @@ impl DaemonManager {
     /// Upgrade: stop service, replace binary, restart.
     /// If installation fails, attempt to reload the old service.
     async fn upgrade(&self) -> Result<()> {
-        plist::unload_service(&self.plist_path).await?;
+        Self::stop_service(&self.service_file_path).await?;
 
         if let Err(e) = self.do_install().await {
             log::error!("Upgrade failed, reloading old service: {}", e);
-            let _ = plist::load_service(&self.plist_path).await;
+            let _ = Self::start_service(&self.service_file_path).await;
             return Err(e);
         }
 
         Ok(())
     }
 
-    /// Shared install steps: directories, binary, plist, load, health check.
+    /// Shared install steps: directories, binary, service file, start, health check.
     async fn do_install(&self) -> Result<()> {
         self.ensure_directories()?;
         self.install_binary()?;
-        self.install_plist()?;
-        plist::load_service(&self.plist_path).await?;
+        self.install_service_file()?;
+        Self::start_service(&self.service_file_path).await?;
         self.wait_for_health().await
     }
 
@@ -126,16 +156,76 @@ impl DaemonManager {
         Ok(())
     }
 
-    /// Write (or overwrite) the launchd plist file.
-    fn install_plist(&self) -> Result<()> {
-        let content = plist::render_plist(&self.binary_path, &self.log_dir, &self.home_dir);
+    /// Write (or overwrite) the platform-specific service file.
+    fn install_service_file(&self) -> Result<()> {
+        let content = self.render_service_file();
 
-        if let Some(parent) = self.plist_path.parent() {
+        if let Some(parent) = self.service_file_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        std::fs::write(&self.plist_path, content).context("Failed to write launchd plist")?;
+        std::fs::write(&self.service_file_path, content)
+            .context("Failed to write service file")?;
         Ok(())
+    }
+
+    /// Render the platform-specific service file content.
+    fn render_service_file(&self) -> String {
+        #[cfg(target_os = "macos")]
+        {
+            super::plist::render_plist(&self.binary_path, &self.log_dir, &self.home_dir)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            super::systemd::render_unit(&self.binary_path, &self.log_dir, &self.home_dir)
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            // Windows is not yet supported for daemon management.
+            String::new()
+        }
+    }
+
+    /// Start the daemon service (platform-specific).
+    async fn start_service(_service_file_path: &PathBuf) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        {
+            super::plist::load_service(_service_file_path).await
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let _ = _service_file_path;
+            super::systemd::start_service().await
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let _ = _service_file_path;
+            anyhow::bail!("Windows daemon management is not yet supported")
+        }
+    }
+
+    /// Stop the daemon service (platform-specific).
+    async fn stop_service(_service_file_path: &PathBuf) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        {
+            super::plist::unload_service(_service_file_path).await
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let _ = _service_file_path;
+            super::systemd::stop_service().await
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            let _ = _service_file_path;
+            anyhow::bail!("Windows daemon management is not yet supported")
+        }
     }
 
     /// Create required directories.

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -1,6 +1,11 @@
 mod health;
 mod manager;
+
+#[cfg(target_os = "macos")]
 mod plist;
+
+#[cfg(target_os = "linux")]
+mod systemd;
 
 pub use health::check_daemon_health;
 pub use manager::DaemonManager;

--- a/src-tauri/src/daemon/systemd.rs
+++ b/src-tauri/src/daemon/systemd.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+const SERVICE_TEMPLATE: &str =
+    include_str!("../../resources/com.lumo.daemon.service.template");
+
+/// Render the systemd unit template with actual paths.
+pub fn render_unit(daemon_path: &Path, log_dir: &Path, home_dir: &Path) -> String {
+    SERVICE_TEMPLATE
+        .replace("{{DAEMON_PATH}}", &daemon_path.display().to_string())
+        .replace("{{LOG_DIR}}", &log_dir.display().to_string())
+        .replace("{{HOME}}", &home_dir.display().to_string())
+}
+
+/// Stop and disable the systemd user service. Ignores errors (service may not exist).
+pub async fn stop_service() -> Result<()> {
+    let _ = tokio::process::Command::new("systemctl")
+        .args(["--user", "stop", "lumo-daemon.service"])
+        .output()
+        .await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+/// Reload systemd daemon and start the user service.
+pub async fn start_service() -> Result<()> {
+    // Reload unit files so systemd picks up the new/updated service.
+    let reload = tokio::process::Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .output()
+        .await
+        .context("Failed to run systemctl daemon-reload")?;
+
+    if !reload.status.success() {
+        let stderr = String::from_utf8_lossy(&reload.stderr);
+        log::warn!("systemctl daemon-reload warning: {}", stderr);
+    }
+
+    // Enable and start the service.
+    let output = tokio::process::Command::new("systemctl")
+        .args(["--user", "enable", "--now", "lumo-daemon.service"])
+        .output()
+        .await
+        .context("Failed to run systemctl enable --now")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("systemctl enable --now failed: {}", stderr);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add Linux daemon lifecycle management via systemd user services, fixing `Failed to run launchctl load` errors on Ubuntu/Linux
- Refactor `DaemonManager` to use `#[cfg(target_os = "...")]` for platform-specific paths and service management
- macOS behavior is unchanged (launchd plist)

## Changes
- **New**: `src-tauri/src/daemon/systemd.rs` — systemd user service management (`systemctl --user`)
- **New**: `src-tauri/resources/com.lumo.daemon.service.template` — systemd unit file template
- **Modified**: `src-tauri/src/daemon/manager.rs` — platform-specific paths and service start/stop dispatch
- **Modified**: `src-tauri/src/daemon/mod.rs` — conditional module loading (`plist` on macOS, `systemd` on Linux)

## Note for existing Linux users

Earlier versions incorrectly ran macOS-specific code on Linux, which may have created stale files. After upgrading, you can safely clean them up:

```bash
# Remove stale macOS launchd plist
rm -f ~/Library/LaunchAgents/com.lumo.daemon.plist

# Remove stale macOS log directory
rm -rf ~/Library/Logs/com.lumo.daemon

# Remove empty parent directories if nothing else is in them
rmdir ~/Library/LaunchAgents ~/Library/Logs ~/Library 2>/dev/null
```

These files are harmless but unnecessary on Linux. The new version uses systemd user services instead (`~/.config/systemd/user/lumo-daemon.service`).

## Test plan
- [x] `cargo check -p app` passes
- [x] `cargo clippy -p app` passes (no warnings)
- [x] `pnpm lint` passes
- [ ] Verify on Ubuntu/Linux that the daemon starts via systemd — @douyux could you help test?

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)