### PR TITLE
feat: add uninstall functionality with CLI and Settings UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +786,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +842,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2456,6 +2552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,6 +2829,8 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "clap",
+ "dirs",
  "opentelemetry-proto",
  "prost",
  "serde",
@@ -3233,6 +3337,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -6572,6 +6682,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -38,6 +38,10 @@ chrono.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 
+# CLI
+clap = { version = "4", features = ["derive"] }
+dirs = "6"
+
 # Logging
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -3,6 +3,7 @@
 //! Receives OTLP telemetry data from Claude Code and stores it in SQLite.
 
 use anyhow::Result;
+use clap::{Parser, Subcommand};
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -11,12 +12,45 @@ mod handlers;
 mod routes;
 mod server;
 mod services;
+mod uninstall;
 
 use config::Config;
 use server::{create_app, shutdown_signal, AppState};
 
+#[derive(Parser)]
+#[command(name = "lumo-daemon", version, about = "Lumo daemon service")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Uninstall the daemon: stop service, remove files, optionally delete all data
+    Uninstall {
+        /// Also delete all user data (~/.lumo/ directory)
+        #[arg(long)]
+        delete_data: bool,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Some(Command::Uninstall { delete_data }) => {
+            // Minimal logging for uninstall
+            tracing_subscriber::registry()
+                .with(tracing_subscriber::fmt::layer())
+                .init();
+            uninstall::run(delete_data).await
+        }
+        None => run_server().await,
+    }
+}
+
+async fn run_server() -> Result<()> {
     // Load configuration
     let config = Config::from_env()?;
     config.validate()?;

--- a/crates/daemon/src/uninstall.rs
+++ b/crates/daemon/src/uninstall.rs
@@ -1,0 +1,128 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use tracing::info;
+
+pub async fn run(delete_data: bool) -> Result<()> {
+    let home_dir = dirs::home_dir().context("Could not determine home directory")?;
+
+    // 1. Stop the running daemon service
+    stop_service(&home_dir).await;
+
+    // 2. Remove the service file
+    remove_service_file(&home_dir);
+
+    // 3. Remove the daemon binary
+    let binary_path = home_dir.join(".lumo/bin/lumo-daemon");
+    if binary_path.exists() {
+        std::fs::remove_file(&binary_path)
+            .with_context(|| format!("Failed to remove {}", binary_path.display()))?;
+        info!("Removed daemon binary: {}", binary_path.display());
+    }
+
+    // 4. Optionally delete all user data
+    if delete_data {
+        let lumo_dir = home_dir.join(".lumo");
+        if lumo_dir.exists() {
+            std::fs::remove_dir_all(&lumo_dir)
+                .with_context(|| format!("Failed to remove {}", lumo_dir.display()))?;
+            info!("Removed data directory: {}", lumo_dir.display());
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let log_dir = home_dir.join("Library/Logs/com.lumo.daemon");
+            if log_dir.exists() {
+                std::fs::remove_dir_all(&log_dir)
+                    .with_context(|| format!("Failed to remove {}", log_dir.display()))?;
+                info!("Removed log directory: {}", log_dir.display());
+            }
+        }
+    }
+
+    info!("Uninstall complete");
+    Ok(())
+}
+
+async fn stop_service(home_dir: &Path) {
+    #[cfg(target_os = "macos")]
+    {
+        let plist = home_dir
+            .join("Library/LaunchAgents")
+            .join("com.lumo.daemon.plist");
+        if plist.exists() {
+            let result = tokio::process::Command::new("launchctl")
+                .args(["unload", &plist.to_string_lossy()])
+                .output()
+                .await;
+            match result {
+                Ok(output) if output.status.success() => {
+                    info!("Unloaded launchd service");
+                }
+                Ok(output) => {
+                    info!(
+                        "launchctl unload exited with {}: {}",
+                        output.status,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+                Err(e) => info!("Failed to run launchctl: {}", e),
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = home_dir;
+        let result = tokio::process::Command::new("systemctl")
+            .args(["--user", "stop", "lumo-daemon.service"])
+            .output()
+            .await;
+        match result {
+            Ok(output) if output.status.success() => {
+                info!("Stopped systemd service");
+            }
+            Ok(output) => {
+                info!(
+                    "systemctl stop exited with {}: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Err(e) => info!("Failed to run systemctl: {}", e),
+        }
+    }
+}
+
+fn remove_service_file(home_dir: &Path) {
+    #[cfg(target_os = "macos")]
+    {
+        let plist = home_dir
+            .join("Library/LaunchAgents")
+            .join("com.lumo.daemon.plist");
+        if plist.exists() {
+            if let Err(e) = std::fs::remove_file(&plist) {
+                info!("Failed to remove plist: {}", e);
+            } else {
+                info!("Removed plist: {}", plist.display());
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let unit = home_dir
+            .join(".config/systemd/user")
+            .join("lumo-daemon.service");
+        if unit.exists() {
+            if let Err(e) = std::fs::remove_file(&unit) {
+                info!("Failed to remove systemd unit: {}", e);
+            } else {
+                info!("Removed systemd unit: {}", unit.display());
+            }
+        }
+        // Reload systemd daemon to pick up the removal
+        let _ = std::process::Command::new("systemctl")
+            .args(["--user", "daemon-reload"])
+            .output();
+    }
+}

--- a/packages/ui/src/bridges/uninstall-bridge.ts
+++ b/packages/ui/src/bridges/uninstall-bridge.ts
@@ -1,0 +1,6 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const UninstallBridge = {
+  uninstall: (deleteAllData: boolean) =>
+    invoke<void>("uninstall_app", { deleteAllData }),
+};

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/packages/ui/src/modules/settings/components/index.ts
+++ b/packages/ui/src/modules/settings/components/index.ts
@@ -1,1 +1,2 @@
 export { NotificationSettings } from "./notification-settings";
+export { UninstallDialog } from "./uninstall-dialog";

--- a/packages/ui/src/modules/settings/components/uninstall-dialog/index.tsx
+++ b/packages/ui/src/modules/settings/components/uninstall-dialog/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+
+interface UninstallDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (deleteAllData: boolean) => void;
+}
+
+export function UninstallDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: UninstallDialogProps) {
+  const [deleteData, setDeleteData] = useState(false);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Uninstall Lumo</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will stop the daemon, remove the service configuration, and
+            delete the daemon binary. The app will close after uninstalling.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="flex items-center gap-2 py-2">
+          <Checkbox
+            id="delete-data"
+            checked={deleteData}
+            onCheckedChange={(checked) => setDeleteData(checked === true)}
+          />
+          <Label htmlFor="delete-data" className="text-sm">
+            Also delete all data (database, logs, daemon)
+          </Label>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setDeleteData(false)}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => onConfirm(deleteData)}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Uninstall
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/ui/src/modules/settings/constants.ts
+++ b/packages/ui/src/modules/settings/constants.ts
@@ -59,4 +59,5 @@ export const TERMINAL_NOTIF_OPTIONS = [
 export const SETTINGS_SECTIONS = [
   { id: "notifications", label: "Notifications" },
   { id: "system", label: "System" },
+  { id: "uninstall", label: "Uninstall" },
 ] as const;

--- a/packages/ui/src/modules/settings/index.tsx
+++ b/packages/ui/src/modules/settings/index.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { invoke } from "@tauri-apps/api/core";
-import { Bell, FileText, Monitor } from "lucide-react";
+import { Bell, FileText, Monitor, Trash2 } from "lucide-react";
 import { CardError } from "@/components/card-error";
 import { CardLoading } from "@/components/card-loading";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { NotificationSettings } from "./components";
+import { NotificationSettings, UninstallDialog } from "./components";
 import { SETTINGS_SECTIONS } from "./constants";
 import { useService } from "./use-service";
 
 const SECTION_ICONS = {
   notifications: Bell,
   system: Monitor,
+  uninstall: Trash2,
 } as const;
 
 export function Settings() {
@@ -28,6 +29,9 @@ export function Settings() {
     terminalNotifChannel,
     isTerminalNotifLoading,
     setTerminalNotifChannel,
+    uninstallDialogOpen,
+    setUninstallDialogOpen,
+    handleUninstall,
   } = useService();
 
   return (
@@ -103,6 +107,35 @@ export function Settings() {
                 </CardContent>
               </Card>
             )}
+
+            {activeSection === "uninstall" && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Uninstall</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <p className="text-sm text-muted-foreground">
+                    Remove Lumo from your system. This will stop the daemon,
+                    remove the service configuration, and delete the daemon
+                    binary.
+                  </p>
+                  <Button
+                    variant="destructive"
+                    className="gap-2"
+                    onClick={() => setUninstallDialogOpen(true)}
+                  >
+                    <Trash2 className="size-4" />
+                    Uninstall Lumo
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
+
+            <UninstallDialog
+              open={uninstallDialogOpen}
+              onOpenChange={setUninstallDialogOpen}
+              onConfirm={handleUninstall}
+            />
           </div>
         </div>
       </div>

--- a/packages/ui/src/modules/settings/types.ts
+++ b/packages/ui/src/modules/settings/types.ts
@@ -20,4 +20,7 @@ export interface UseServiceReturn {
   terminalNotifChannel: TerminalNotifChannel;
   isTerminalNotifLoading: boolean;
   setTerminalNotifChannel: (channel: TerminalNotifChannel) => void;
+  uninstallDialogOpen: boolean;
+  setUninstallDialogOpen: (open: boolean) => void;
+  handleUninstall: (deleteAllData: boolean) => void;
 }

--- a/packages/ui/src/modules/settings/use-service.ts
+++ b/packages/ui/src/modules/settings/use-service.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { NotificationSettingsBridge } from "@/bridges/notification-settings-bridge";
+import { UninstallBridge } from "@/bridges/uninstall-bridge";
 import {
   type NotificationSettingResponse,
   TerminalNotifChannel,
@@ -12,6 +13,7 @@ import type { UseServiceReturn } from "./types";
 export function useService(): UseServiceReturn {
   const queryClient = useQueryClient();
   const [activeSection, setActiveSection] = useState("notifications");
+  const [uninstallDialogOpen, setUninstallDialogOpen] = useState(false);
 
   const settingsQuery = useQuery({
     queryKey: ["notification_settings"],
@@ -76,6 +78,15 @@ export function useService(): UseServiceReturn {
     },
   });
 
+  const uninstallMutation = useMutation({
+    mutationFn: (deleteAllData: boolean) =>
+      UninstallBridge.uninstall(deleteAllData),
+  });
+
+  const handleUninstall = (deleteAllData: boolean) => {
+    uninstallMutation.mutate(deleteAllData);
+  };
+
   return {
     settings: settingsQuery.data ?? [],
     isLoading: settingsQuery.isLoading,
@@ -87,5 +98,8 @@ export function useService(): UseServiceReturn {
     terminalNotifChannel: terminalNotifQuery.data ?? TerminalNotifChannel.Auto,
     isTerminalNotifLoading: terminalNotifQuery.isLoading,
     setTerminalNotifChannel: terminalNotifMutation.mutate,
+    uninstallDialogOpen,
+    setUninstallDialogOpen,
+    handleUninstall,
   };
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod user_commands;
 pub mod projects_commands;
 pub mod marketplace_commands;
 pub mod skills_commands;
+pub mod uninstall_commands;
 pub mod wrapped_commands;
 
 pub use analytics_commands::*;
@@ -32,6 +33,7 @@ pub use user_commands::*;
 pub use projects_commands::*;
 pub use marketplace_commands::*;
 pub use skills_commands::*;
+pub use uninstall_commands::*;
 pub use wrapped_commands::*;
 
 /// Macro to generate the Tauri command handler with all registered commands
@@ -112,6 +114,8 @@ macro_rules! app_commands {
             commands::update_notification_setting,
             commands::get_terminal_notif_channel,
             commands::set_terminal_notif_channel,
+            // Uninstall commands
+            commands::uninstall_app,
             // System commands
             commands::open_log_directory,
         ]

--- a/src-tauri/src/commands/uninstall_commands.rs
+++ b/src-tauri/src/commands/uninstall_commands.rs
@@ -1,0 +1,30 @@
+use tauri::{command, AppHandle};
+
+#[command]
+pub async fn uninstall_app(app_handle: AppHandle, delete_all_data: bool) -> Result<(), String> {
+    let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let daemon_binary = home_dir.join(".lumo/bin/lumo-daemon");
+
+    if daemon_binary.exists() {
+        let mut cmd = tokio::process::Command::new(&daemon_binary);
+        cmd.arg("uninstall");
+        if delete_all_data {
+            cmd.arg("--delete-data");
+        }
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("Failed to run daemon uninstall: {}", e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            log::warn!("Daemon uninstall stderr: {}", stderr);
+        }
+    } else {
+        log::warn!("Daemon binary not found at {}, skipping", daemon_binary.display());
+    }
+
+    app_handle.exit(0);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add daemon CLI `uninstall` subcommand: stops service, removes service files, optionally deletes all user data (`--delete-data`)
- Add Tauri `uninstall_app` command that invokes the daemon CLI
- Add uninstall section in Settings page with confirmation dialog and delete-data checkbox

## Test plan
- [ ] `cargo check -p app` and `cargo check -p lumo-daemon` pass
- [ ] `~/.lumo/bin/lumo-daemon uninstall` stops daemon and removes service file
- [ ] `~/.lumo/bin/lumo-daemon uninstall --delete-data` also removes `~/.lumo/` directory
- [ ] Settings > Uninstall button opens dialog, confirming triggers uninstall and app exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)