### PR TITLE
feat: redesign session detail with ambient document flow and replay

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,8 @@
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/packages/ui/src/components/markdown-viewer/index.tsx
+++ b/packages/ui/src/components/markdown-viewer/index.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
+import { visit } from "unist-util-visit";
 import "highlight.js/styles/github.css";
 import { markdownComponents } from "./markdown-components";
 
@@ -12,11 +13,26 @@ interface MarkdownViewerProps {
   className?: string;
 }
 
+/**
+ * Remark plugin that converts HTML AST nodes back to text nodes.
+ * This prevents `<unknown-tag>content</unknown-tag>` from being
+ * silently swallowed by the markdown parser.
+ */
+function remarkPreserveHtml() {
+  return (tree: any) => {
+    visit(tree, "html", (node: any, index: any, parent: any) => {
+      if (parent && index !== undefined && node.value) {
+        parent.children[index] = { type: "text", value: node.value };
+      }
+    });
+  };
+}
+
 export function MarkdownViewer({ content, className }: MarkdownViewerProps) {
   return (
     <div className={className}>
       <ReactMarkdown
-        remarkPlugins={[remarkFrontmatter, remarkGfm]}
+        remarkPlugins={[remarkFrontmatter, remarkGfm, remarkPreserveHtml]}
         rehypePlugins={[rehypeHighlight]}
         components={markdownComponents}
       >

--- a/packages/ui/src/hooks/use-scroll-to-bottom.ts
+++ b/packages/ui/src/hooks/use-scroll-to-bottom.ts
@@ -40,7 +40,8 @@ export function useScrollToBottom({
     }
   }, [itemCount, onScrollToBottom, autoScrollOnInitialLoad]);
 
-  // Track scroll position — depend on itemCount so listener attaches after content renders
+  // Track scroll position — itemCount in deps ensures re-attach when content first renders
+  // biome-ignore lint/correctness/useExhaustiveDependencies: itemCount triggers re-attach when scroll container mounts
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -56,7 +57,7 @@ export function useScrollToBottom({
     handleScroll();
     el.addEventListener("scroll", handleScroll, { passive: true });
     return () => el.removeEventListener("scroll", handleScroll);
-  }, [scrollRef]);
+  }, [scrollRef, itemCount]);
 
   const scrollToBottom = useCallback(() => {
     onScrollToBottom();

--- a/packages/ui/src/modules/session-detail/components/assistant-text/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/assistant-text/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bot, ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -25,10 +25,9 @@ export function AssistantText({ item }: AssistantTextProps) {
     : item.text;
 
   return (
-    <section className="px-4 py-2 md:px-6">
-      <div className="border-l-2 border-primary/20 pl-4">
+    <section className="px-4 py-3 md:px-6">
+      <div>
         <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
-          <Bot className="size-3.5" />
           <span className="font-medium text-foreground">Claude</span>
           {displayModel && (
             <Badge

--- a/packages/ui/src/modules/session-detail/components/replay-bar/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/replay-bar/index.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Pause, Play, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ReplaySpeed } from "../../use-replay";
+
+const SPEEDS: ReplaySpeed[] = [1, 2, 4, 8];
+
+interface ReplayBarProps {
+  isPlaying: boolean;
+  progress: number;
+  speed: ReplaySpeed;
+  visibleCount: number;
+  totalCount: number;
+  onTogglePlay: () => void;
+  onStop: () => void;
+  onSpeedChange: (speed: ReplaySpeed) => void;
+  onSeek: (progress: number) => void;
+}
+
+export function ReplayBar({
+  isPlaying,
+  progress,
+  speed,
+  visibleCount,
+  totalCount,
+  onTogglePlay,
+  onStop,
+  onSpeedChange,
+  onSeek,
+}: ReplayBarProps) {
+  const handleProgressClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const p = Math.max(0, Math.min(1, x / rect.width));
+    onSeek(p);
+  };
+
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4 md:px-6">
+      <div className="flex items-center gap-3 rounded-xl bg-card/90 px-4 py-2.5 shadow-lg ring-1 ring-border/50 backdrop-blur-sm">
+        {/* Play / Pause */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={onTogglePlay}
+        >
+          {isPlaying ? (
+            <Pause className="size-3.5" />
+          ) : (
+            <Play className="size-3.5" />
+          )}
+        </Button>
+
+        {/* Progress bar */}
+        <div
+          className="relative h-1.5 flex-1 cursor-pointer rounded-full bg-muted"
+          onClick={handleProgressClick}
+        >
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-primary/70 transition-[width] duration-150"
+            style={{ width: `${progress * 100}%` }}
+          />
+        </div>
+
+        {/* Counter */}
+        <span className="min-w-[4rem] text-center font-mono text-[11px] text-muted-foreground">
+          {visibleCount} / {totalCount}
+        </span>
+
+        {/* Speed */}
+        <div className="flex items-center gap-0.5">
+          {SPEEDS.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className={cn(
+                "rounded-md px-1.5 py-0.5 text-[11px] font-medium transition-colors",
+                s === speed
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+              onClick={() => onSpeedChange(s)}
+            >
+              {s}x
+            </button>
+          ))}
+        </div>
+
+        {/* Stop */}
+        <Button variant="ghost" size="icon" className="size-7" onClick={onStop}>
+          <X className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/session-detail/components/session-header/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/session-header/index.tsx
@@ -7,11 +7,13 @@ import {
   FolderOpen,
   GitBranch,
   MessageSquare,
+  Play,
   Timer,
   Zap,
 } from "lucide-react";
 import { DetailHeader } from "@/components/detail-header";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { fmt, formatDurationMixed } from "@/lib/format";
 import {
   formatDate,
@@ -19,6 +21,7 @@ import {
   getProjectName,
   getShortId,
 } from "../../libs";
+import { cleanDisplayText } from "../shared/text-utils";
 import type { SessionHeaderProps } from "./types";
 
 export function SessionHeader({
@@ -28,11 +31,11 @@ export function SessionHeader({
   stats,
   collapsed = false,
   onBack,
+  onReplay,
 }: SessionHeaderProps) {
+  const rawTitle = session.summary || session.firstPrompt || "";
   const title =
-    session.summary ||
-    session.firstPrompt ||
-    `Session ${getShortId(session.sessionId)}`;
+    cleanDisplayText(rawTitle) || `Session ${getShortId(session.sessionId)}`;
 
   return (
     <DetailHeader
@@ -43,7 +46,18 @@ export function SessionHeader({
           {getShortId(session.sessionId)}
         </Badge>
       }
-      actions={undefined}
+      actions={
+        onReplay ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            onClick={onReplay}
+          >
+            <Play className="size-3.5" />
+          </Button>
+        ) : undefined
+      }
       meta={
         !collapsed ? (
           <>

--- a/packages/ui/src/modules/session-detail/components/session-header/types.ts
+++ b/packages/ui/src/modules/session-detail/components/session-header/types.ts
@@ -7,4 +7,5 @@ export interface SessionHeaderProps {
   stats: ClaudeSessionStats;
   collapsed?: boolean;
   onBack: () => void;
+  onReplay?: () => void;
 }

--- a/packages/ui/src/modules/session-detail/components/shared/text-utils.ts
+++ b/packages/ui/src/modules/session-detail/components/shared/text-utils.ts
@@ -1,9 +1,42 @@
-const COMMAND_TAGS = new Set([
+/** All Claude Code special XML tags that should be stripped or handled specially. */
+const SPECIAL_TAGS = new Set([
+  // Command / skill
   "command-name",
   "command-message",
   "command-args",
+  "skill-format",
+  // Terminal output
   "local-command-stdout",
   "local-command-stderr",
+  "local-command-caveat",
+  "bash-input",
+  "bash-stdout",
+  "bash-stderr",
+  // Task / agent
+  "task-notification",
+  "task-id",
+  "tool-use-id",
+  "task-type",
+  "output-file",
+  "status",
+  "summary",
+  "reason",
+  "tick",
+  "teammate-message",
+  "channel-message",
+  "channel",
+  "cross-session-message",
+  // Worktree
+  "worktree",
+  "worktreePath",
+  "worktreeBranch",
+  // UI meta
+  "fork-boilerplate",
+  "system-reminder",
+  "ultraplan",
+  "remote-review",
+  "remote-review-progress",
+  "user-prompt-submit-hook",
 ]);
 
 const HTML_LIKE_TAGS = new Set([
@@ -66,7 +99,7 @@ export function extractSlashCommand(text: string): SlashCommand | null {
   };
 }
 
-export function extractStandaloneStdout(text: string): string | null {
+function extractStandaloneStdout(text: string): string | null {
   const stripped = text.replace(/\n{3,}/g, "\n\n").trim();
   const stdoutMatch = stripped.match(
     /^<local-command-stdout>([\s\S]*?)<\/local-command-stdout>$/,
@@ -74,16 +107,27 @@ export function extractStandaloneStdout(text: string): string | null {
   return stdoutMatch?.[1].trim() || null;
 }
 
+/** Build a regex alternation from the SPECIAL_TAGS set. */
+const SPECIAL_TAGS_PATTERN = [...SPECIAL_TAGS].join("|");
+
 export function sanitizeMessageText(text: string): string {
+  // 1. Convert recognized meta-tags (system-reminder etc.) to blockquotes
+  // 2. Strip all special paired tags: <tag>content</tag>
+  // 3. Strip any remaining orphaned special tags: <tag> or </tag>
+  const pairedRe = new RegExp(
+    `<(?:${SPECIAL_TAGS_PATTERN})(?:\\s[^>]*)?>` +
+      `[\\s\\S]*?` +
+      `<\\/(?:${SPECIAL_TAGS_PATTERN})>`,
+    "g",
+  );
+  const orphanRe = new RegExp(
+    `<\\/?(?:${SPECIAL_TAGS_PATTERN})(?:\\s[^>]*)?>`,
+    "g",
+  );
+
   return renderXmlLikeMetaTags(text)
-    .replace(
-      /<\/?(?:command-name|command-message|command-args|local-command-stdout|local-command-stderr)>[\s\S]*?<\/(?:command-name|command-message|command-args|local-command-stdout|local-command-stderr)>/g,
-      "",
-    )
-    .replace(
-      /<\/?(?:command-name|command-message|command-args|local-command-stdout|local-command-stderr)(?:\s[^>]*)?>/g,
-      "",
-    )
+    .replace(pairedRe, "")
+    .replace(orphanRe, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
@@ -94,7 +138,7 @@ export function renderXmlLikeMetaTags(text: string): string {
     (full: string, tagName: string, content: string) => {
       const tag = tagName.toLowerCase();
 
-      if (COMMAND_TAGS.has(tag) || HTML_LIKE_TAGS.has(tag)) {
+      if (SPECIAL_TAGS.has(tag) || HTML_LIKE_TAGS.has(tag)) {
         return full;
       }
       if (!META_TAG_LABELS[tag] && !/[-_]/.test(tag)) {
@@ -123,6 +167,61 @@ function toHumanTagLabel(tag: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+/** Strip ANSI escape sequences (colors, bold, dim, etc.) from terminal output. */
+export function stripAnsiCodes(text: string): string {
+  const ESC = String.fromCharCode(0x1b);
+  const BEL = String.fromCharCode(0x07);
+  // CSI sequences: ESC[...letter
+  const csi = new RegExp(`${ESC}\\[[0-9;]*[A-Za-z]`, "g");
+  // OSC sequences: ESC]...BEL
+  const osc = new RegExp(`${ESC}\\][^${BEL}]*${BEL}`, "g");
+  return text
+    .replace(csi, "")
+    .replace(osc, "")
+    .replace(/\[(\d+)m/g, "");
+}
+
+/**
+ * Clean text for display (titles, previews).
+ * Only processes text that is actually a slash command or system metadata.
+ * Regular user text is returned as-is to avoid stripping content that
+ * happens to look like XML tags.
+ */
+export function cleanDisplayText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+
+  // Caveat messages — hide entirely
+  if (trimmed.startsWith("<local-command-caveat>")) {
+    return "";
+  }
+
+  // If it's a slash command, format it
+  const command = extractSlashCommand(trimmed);
+  if (command) {
+    const name = command.name.startsWith("/")
+      ? command.name
+      : `/${command.name}`;
+    return `${name}${command.args ? ` ${command.args}` : ""}`;
+  }
+
+  // If it's purely a local-command-stdout block (standalone output, no user text)
+  if (
+    trimmed.startsWith("<local-command-stdout>") ||
+    trimmed.startsWith("<local-command-stderr>")
+  ) {
+    const stdout = extractStandaloneStdout(trimmed);
+    if (stdout) return stripAnsiCodes(stdout).slice(0, 100);
+    return "";
+  }
+
+  // Regular user text — collapse to single line, truncate
+  const singleLine = trimmed.replace(/\n+/g, " ").replace(/\s+/g, " ");
+  return singleLine.length > 120
+    ? `${singleLine.slice(0, 120)}...`
+    : singleLine;
 }
 
 export function formatToolInput(input: string): string {

--- a/packages/ui/src/modules/session-detail/components/thinking-block/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/thinking-block/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Brain, ChevronDown, ChevronRight, EyeOff } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
-import { cn } from "@/lib/utils";
 import type { TimelineThinkingItem } from "../../types";
 
 interface ThinkingBlockProps {
@@ -13,39 +12,28 @@ export function ThinkingBlock({ item }: ThinkingBlockProps) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <section className="px-4 py-1 md:px-6">
-      <div className="rounded-lg border border-dashed border-border bg-muted/20">
-        <button
-          type="button"
-          className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-muted-foreground hover:text-foreground"
-          onClick={() => setExpanded(!expanded)}
-        >
-          {item.redacted ? (
-            <EyeOff className="size-3.5 shrink-0" />
-          ) : (
-            <Brain className="size-3.5 shrink-0" />
-          )}
-          <span className="font-medium">
-            {item.redacted ? "Redacted thinking" : "Thinking"}
-          </span>
-          {expanded ? (
-            <ChevronDown className="ml-auto size-3.5 shrink-0" />
-          ) : (
-            <ChevronRight className="ml-auto size-3.5 shrink-0" />
-          )}
-        </button>
-        {expanded && (
-          <div
-            className={cn(
-              "max-h-[400px] overflow-auto border-t border-dashed border-border px-3 py-2",
-            )}
-          >
-            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
-              {item.text}
-            </pre>
-          </div>
+    <section className="px-4 py-0.5 md:px-6">
+      <button
+        type="button"
+        className="flex items-center gap-1.5 text-[11px] text-muted-foreground/50 hover:text-muted-foreground"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span className="font-medium">
+          {item.redacted ? "Redacted thinking" : "Thinking"}
+        </span>
+        {expanded ? (
+          <ChevronDown className="size-3" />
+        ) : (
+          <ChevronRight className="size-3" />
         )}
-      </div>
+      </button>
+      {expanded && (
+        <div className="mt-1 max-h-[400px] overflow-auto pl-4">
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] italic text-muted-foreground/60">
+            {item.text}
+          </pre>
+        </div>
+      )}
     </section>
   );
 }

--- a/packages/ui/src/modules/session-detail/components/timeline-item/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/timeline-item/index.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import type { TimelineItem as TimelineItemType } from "../../types";
 import { AssistantText } from "../assistant-text";
 import { ThinkingBlock } from "../thinking-block";
+import { ToolGroup } from "../tool-group";
 import { ToolItem } from "../tool-item";
 import { UserBubble } from "../user-bubble";
 
@@ -23,6 +24,8 @@ export const TimelineItem = memo(function TimelineItem({
       return <ThinkingBlock item={item} />;
     case "tool":
       return <ToolItem item={item} />;
+    case "tool-group":
+      return <ToolGroup item={item} />;
     default:
       return null;
   }

--- a/packages/ui/src/modules/session-detail/components/tool-group/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-group/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { TimelineToolGroupItem } from "../../types";
+import { CompactTool } from "../tool-item/compact-tool";
+
+const GROUP_LABELS: Record<string, (n: number) => string> = {
+  read: (n) => `Read ${n} files`,
+  search: (n) => `Searched ${n} patterns`,
+};
+
+interface ToolGroupProps {
+  item: TimelineToolGroupItem;
+}
+
+/**
+ * Collapsed group of consecutive Read or Search tools.
+ * Renders as a single muted line; expands to show individual compact items.
+ */
+export function ToolGroup({ item }: ToolGroupProps) {
+  const [expanded, setExpanded] = useState(false);
+  const label =
+    GROUP_LABELS[item.category]?.(item.items.length) ??
+    `${item.items.length} tool calls`;
+
+  return (
+    <div className="px-4 py-0.5 md:px-6">
+      <button
+        type="button"
+        className="flex items-center gap-2 text-[11px] text-muted-foreground/50 hover:text-muted-foreground"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span className="font-medium">{label}</span>
+        {expanded ? (
+          <ChevronDown className="size-3" />
+        ) : (
+          <ChevronRight className="size-3" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-0.5">
+          {item.items.map((tool) => (
+            <CompactTool key={tool.id} item={tool} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/session-detail/components/tool-item/collapsible-tool.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-item/collapsible-tool.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { TimelineToolItem } from "../../types";
+import { formatToolInput } from "../shared/text-utils";
+import { ToolAgent } from "../tool-viewers/tool-agent";
+import { ToolGeneric } from "../tool-viewers/tool-generic";
+import { ToolMcp } from "../tool-viewers/tool-mcp";
+
+interface CollapsibleToolProps {
+  item: TimelineToolItem;
+}
+
+/**
+ * Lightweight collapsible for Agent, MCP, and unknown tools.
+ * No card border — just an expandable text block.
+ */
+export function CollapsibleTool({ item }: CollapsibleToolProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const summary = item.input
+    ? formatToolInput(item.input)
+    : (item.filePath ?? "");
+  const preview = summary.length > 80 ? `${summary.slice(0, 80)}...` : summary;
+
+  return (
+    <section className="px-4 py-1 md:px-6">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left text-[11px] text-muted-foreground/60 hover:text-muted-foreground"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span className="shrink-0 font-medium">{item.toolName}</span>
+        <span className="min-w-0 flex-1 truncate font-mono">{preview}</span>
+        {expanded ? (
+          <ChevronDown className="size-3 shrink-0" />
+        ) : (
+          <ChevronRight className="size-3 shrink-0" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-1.5 pl-4">
+          <CollapsibleContent item={item} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CollapsibleContent({ item }: { item: TimelineToolItem }) {
+  if (item.toolName === "Agent") {
+    return <ToolAgent input={item.input} output={item.output} />;
+  }
+  if (item.toolName.startsWith("mcp__")) {
+    return (
+      <ToolMcp
+        toolName={item.toolName}
+        input={item.input}
+        output={item.output}
+      />
+    );
+  }
+  return (
+    <ToolGeneric
+      toolName={item.toolName}
+      input={item.input}
+      output={item.output}
+    />
+  );
+}

--- a/packages/ui/src/modules/session-detail/components/tool-item/compact-tool.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-item/compact-tool.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { TimelineToolItem } from "../../types";
+import { formatToolInput } from "../shared/text-utils";
+
+interface CompactToolProps {
+  item: TimelineToolItem;
+}
+
+/**
+ * Compact tool rendering for Read, Search, Glob, etc.
+ * Single muted line — minimal visual weight.
+ */
+export function CompactTool({ item }: CompactToolProps) {
+  const summary = item.input
+    ? formatToolInput(item.input)
+    : (item.filePath ?? "");
+
+  return (
+    <div className="px-4 py-0.5 md:px-6">
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground/50">
+        <span className="shrink-0 font-medium">{item.toolName}</span>
+        <span className="min-w-0 truncate font-mono">{summary}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/session-detail/components/tool-item/constants.ts
+++ b/packages/ui/src/modules/session-detail/components/tool-item/constants.ts
@@ -1,0 +1,40 @@
+/** Returns true if the file path looks like a Claude Code plan file. */
+export function isPlanFile(filePath: string | undefined): boolean {
+  if (!filePath) return false;
+  return filePath.includes(".claude/plans/");
+}
+
+/** Tools whose content (diff, terminal output) is shown directly — no collapse. */
+export const INLINE_TOOLS = new Set(["Edit", "Write", "NotebookEdit", "Bash"]);
+
+/** Tools shown as a single muted line — minimal visual weight. */
+export const COMPACT_TOOLS = new Set([
+  "Read",
+  "Glob",
+  "Grep",
+  "WebSearch",
+  "WebFetch",
+  "Search",
+]);
+
+/** Resolve the file path from a tool item's filePath or input JSON. */
+export function resolveFilePath(
+  filePath: string | undefined,
+  input: string | undefined,
+): string | undefined {
+  if (filePath) return filePath;
+  if (!input) return undefined;
+  try {
+    const parsed = JSON.parse(input);
+    return typeof parsed.file_path === "string" ? parsed.file_path : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Shorten a file path for display — keep last 3 segments. */
+export function shortenPath(filePath: string): string {
+  const parts = filePath.split("/");
+  if (parts.length <= 3) return filePath;
+  return `.../${parts.slice(-3).join("/")}`;
+}

--- a/packages/ui/src/modules/session-detail/components/tool-item/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-item/index.tsx
@@ -1,154 +1,27 @@
 "use client";
 
-import {
-  ChevronDown,
-  ChevronRight,
-  Clock3,
-  FilePen,
-  FilePlus,
-  FileSearch,
-  FileText,
-  Globe,
-  Search,
-  Terminal,
-  Wrench,
-} from "lucide-react";
-import { useState } from "react";
-import { cn } from "@/lib/utils";
-import { formatMessageTime } from "../../libs";
 import type { TimelineToolItem } from "../../types";
-import { formatToolInput } from "../shared/text-utils";
-import { ToolBash } from "../tool-viewers/tool-bash";
-import { ToolEdit } from "../tool-viewers/tool-edit";
-import { ToolGeneric } from "../tool-viewers/tool-generic";
-import { ToolRead } from "../tool-viewers/tool-read";
-import { ToolSearch } from "../tool-viewers/tool-search";
-import { ToolWrite } from "../tool-viewers/tool-write";
-
-const TOOL_ICONS: Record<string, React.ReactNode> = {
-  Read: <FileText className="size-3.5" />,
-  Edit: <FilePen className="size-3.5" />,
-  Write: <FilePlus className="size-3.5" />,
-  NotebookEdit: <FilePlus className="size-3.5" />,
-  Bash: <Terminal className="size-3.5" />,
-  Grep: <FileSearch className="size-3.5" />,
-  Glob: <FileSearch className="size-3.5" />,
-  WebSearch: <Globe className="size-3.5" />,
-  WebFetch: <Globe className="size-3.5" />,
-  Search: <Search className="size-3.5" />,
-};
-
-const SEARCH_TOOLS = new Set(["Grep", "Glob", "WebSearch", "WebFetch"]);
+import { CollapsibleTool } from "./collapsible-tool";
+import { CompactTool } from "./compact-tool";
+import { COMPACT_TOOLS, INLINE_TOOLS } from "./constants";
+import { InlineTool } from "./inline-tool";
 
 interface ToolItemProps {
   item: TimelineToolItem;
 }
 
+/**
+ * Route tool items to the appropriate renderer based on tool type:
+ * - Inline (Edit/Write/Bash): content directly visible
+ * - Compact (Read/Search): single muted line
+ * - Collapsible (Agent/MCP/other): lightweight expandable
+ */
 export function ToolItem({ item }: ToolItemProps) {
-  const [expanded, setExpanded] = useState(!!item.isError);
-
-  const icon = TOOL_ICONS[item.toolName] ?? <Wrench className="size-3.5" />;
-  const summary = item.input
-    ? formatToolInput(item.input)
-    : (item.filePath ?? "");
-
-  return (
-    <section className="px-4 py-1 md:px-6">
-      <div className="rounded-lg border border-border bg-card/50">
-        <button
-          type="button"
-          className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/30"
-          onClick={() => setExpanded(!expanded)}
-        >
-          <span className="shrink-0 text-muted-foreground">{icon}</span>
-          <span className="shrink-0 text-xs font-medium text-foreground">
-            {item.toolName}
-          </span>
-          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
-            {summary}
-          </span>
-          <span
-            className={cn(
-              "size-2 shrink-0 rounded-full",
-              item.isError ? "bg-red-500" : "bg-green-500",
-            )}
-          />
-          <span className="inline-flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
-            <Clock3 className="size-3" />
-            {formatMessageTime(item.timestamp)}
-          </span>
-          {expanded ? (
-            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
-          )}
-        </button>
-
-        {expanded && (
-          <div className="border-t border-border p-3">
-            <ToolContent item={item} />
-          </div>
-        )}
-      </div>
-    </section>
-  );
-}
-
-function ToolContent({ item }: { item: TimelineToolItem }) {
-  switch (item.toolName) {
-    case "Read":
-      return (
-        <ToolRead
-          input={item.input}
-          output={item.output}
-          filePath={item.filePath}
-          fileContent={item.fileContent}
-        />
-      );
-    case "Edit":
-      return (
-        <ToolEdit
-          input={item.input}
-          output={item.output}
-          filePath={item.filePath}
-          fileContent={item.fileContent}
-        />
-      );
-    case "Write":
-    case "NotebookEdit":
-      return (
-        <ToolWrite
-          input={item.input}
-          output={item.output}
-          toolName={item.toolName}
-          filePath={item.filePath}
-          fileContent={item.fileContent}
-        />
-      );
-    case "Bash":
-      return (
-        <ToolBash
-          input={item.input}
-          output={item.output}
-          isError={item.isError}
-        />
-      );
-    default:
-      if (SEARCH_TOOLS.has(item.toolName)) {
-        return (
-          <ToolSearch
-            toolName={item.toolName}
-            input={item.input}
-            output={item.output}
-          />
-        );
-      }
-      return (
-        <ToolGeneric
-          toolName={item.toolName}
-          input={item.input}
-          output={item.output}
-        />
-      );
+  if (INLINE_TOOLS.has(item.toolName)) {
+    return <InlineTool item={item} />;
   }
+  if (COMPACT_TOOLS.has(item.toolName)) {
+    return <CompactTool item={item} />;
+  }
+  return <CollapsibleTool item={item} />;
 }

--- a/packages/ui/src/modules/session-detail/components/tool-item/inline-tool.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-item/inline-tool.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import type { TimelineToolItem } from "../../types";
+import { ToolBash } from "../tool-viewers/tool-bash";
+import { ToolEdit } from "../tool-viewers/tool-edit";
+import { ToolWrite } from "../tool-viewers/tool-write";
+import { isPlanFile, resolveFilePath, shortenPath } from "./constants";
+
+interface InlineToolProps {
+  item: TimelineToolItem;
+}
+
+/**
+ * Inline tool rendering for Edit, Write, and Bash.
+ * Content is directly visible — no card, no collapse.
+ */
+export function InlineTool({ item }: InlineToolProps) {
+  const filePath = resolveFilePath(item.filePath, item.input);
+  const displayPath = filePath ? shortenPath(filePath) : undefined;
+  const isPlan = isPlanFile(filePath);
+  const label = isPlan
+    ? item.toolName === "Edit"
+      ? "Updated plan"
+      : "Created plan"
+    : item.toolName;
+
+  return (
+    <section className="px-4 py-1.5 md:px-6">
+      {/* Header: tool name + file path */}
+      {(item.toolName !== "Bash" || displayPath) && (
+        <div className="mb-1 flex items-center gap-2">
+          <span className="text-[11px] font-medium text-muted-foreground/70">
+            {label}
+          </span>
+          {displayPath && (
+            <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground/50">
+              {displayPath}
+            </span>
+          )}
+          {item.isError && (
+            <AlertCircle className="size-3 shrink-0 text-destructive/70" />
+          )}
+        </div>
+      )}
+
+      {/* Content: directly visible */}
+      <InlineContent item={item} />
+    </section>
+  );
+}
+
+function InlineContent({ item }: { item: TimelineToolItem }) {
+  switch (item.toolName) {
+    case "Edit":
+      return (
+        <ToolEdit
+          input={item.input}
+          output={item.output}
+          filePath={item.filePath}
+          fileContent={item.fileContent}
+        />
+      );
+    case "Write":
+    case "NotebookEdit":
+      return (
+        <ToolWrite
+          input={item.input}
+          output={item.output}
+          toolName={item.toolName}
+          filePath={item.filePath}
+          fileContent={item.fileContent}
+        />
+      );
+    case "Bash":
+      return (
+        <ToolBash
+          input={item.input}
+          output={item.output}
+          isError={item.isError}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/packages/ui/src/modules/session-detail/components/tool-viewers/index.ts
+++ b/packages/ui/src/modules/session-detail/components/tool-viewers/index.ts
@@ -1,6 +1,6 @@
+export { ToolAgent } from "./tool-agent";
 export { ToolBash } from "./tool-bash";
 export { ToolEdit } from "./tool-edit";
 export { ToolGeneric } from "./tool-generic";
-export { ToolRead } from "./tool-read";
-export { ToolSearch } from "./tool-search";
+export { ToolMcp } from "./tool-mcp";
 export { ToolWrite } from "./tool-write";

--- a/packages/ui/src/modules/session-detail/components/tool-viewers/tool-agent/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-viewers/tool-agent/index.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { parseRichContent } from "../../shared/content-parser";
+import { MarkdownViewer } from "../../viewers/markdown-viewer";
+
+interface ToolAgentProps {
+  input?: string;
+  output?: string;
+}
+
+export function ToolAgent({ input, output }: ToolAgentProps) {
+  const [promptExpanded, setPromptExpanded] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      return JSON.parse(input ?? "{}") as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }, [input]);
+
+  const description =
+    typeof parsed.description === "string" ? parsed.description : undefined;
+  const subagentType =
+    typeof parsed.subagent_type === "string" ? parsed.subagent_type : undefined;
+  const prompt = typeof parsed.prompt === "string" ? parsed.prompt : undefined;
+
+  const parsedOutput = parseRichContent(output);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {subagentType && (
+          <Badge
+            variant="outline"
+            className="rounded-full px-2 text-[10px] capitalize"
+          >
+            {subagentType}
+          </Badge>
+        )}
+        {description && (
+          <span className="text-xs font-medium text-foreground">
+            {description}
+          </span>
+        )}
+      </div>
+
+      {prompt && (
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+            onClick={() => setPromptExpanded(!promptExpanded)}
+          >
+            {promptExpanded ? (
+              <ChevronDown className="size-3" />
+            ) : (
+              <ChevronRight className="size-3" />
+            )}
+            Prompt
+          </button>
+          {promptExpanded && (
+            <div className="mt-1 max-h-[300px] overflow-auto rounded-lg bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+              <pre className="whitespace-pre-wrap break-words">{prompt}</pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {parsedOutput.markdown.trim() && (
+        <div className="max-h-[400px] overflow-auto rounded-lg bg-muted/20 px-3 py-2 text-sm">
+          <MarkdownViewer content={parsedOutput.markdown} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/session-detail/components/tool-viewers/tool-mcp/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-viewers/tool-mcp/index.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { parseRichContent } from "../../shared/content-parser";
+import { MarkdownViewer } from "../../viewers/markdown-viewer";
+
+interface ToolMcpProps {
+  toolName: string;
+  input?: string;
+  output?: string;
+}
+
+/** Parse "mcp__serverName__toolName" into parts. */
+function parseMcpToolName(name: string): {
+  server: string;
+  tool: string;
+} | null {
+  const parts = name.split("__");
+  if (parts.length >= 3 && parts[0] === "mcp") {
+    return { server: parts[1], tool: parts.slice(2).join("__") };
+  }
+  return null;
+}
+
+export function ToolMcp({ toolName, input, output }: ToolMcpProps) {
+  const mcpParts = parseMcpToolName(toolName);
+  const parsedInput = useMemo(() => {
+    if (!input) return null;
+    try {
+      return JSON.parse(input) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }, [input]);
+
+  const parsedOutput = parseRichContent(output);
+
+  return (
+    <div className="space-y-2">
+      {mcpParts && (
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="rounded-full px-2 text-[10px]">
+            {mcpParts.server}
+          </Badge>
+          <span className="text-xs font-medium text-foreground">
+            {mcpParts.tool}
+          </span>
+        </div>
+      )}
+
+      {parsedInput && (
+        <div className="space-y-1 rounded-lg bg-muted/30 px-3 py-2">
+          {Object.entries(parsedInput).map(([key, value]) => (
+            <div key={key} className="flex gap-2 text-[11px]">
+              <span className="shrink-0 font-medium text-muted-foreground">
+                {key}:
+              </span>
+              <span className="min-w-0 break-all text-foreground">
+                {typeof value === "string"
+                  ? value.length > 200
+                    ? `${value.slice(0, 200)}...`
+                    : value
+                  : JSON.stringify(value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {parsedOutput.markdown.trim() && (
+        <div className="max-h-[400px] overflow-auto rounded-lg bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground">
+          <MarkdownViewer content={parsedOutput.markdown} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/session-detail/components/tool-viewers/tool-read/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-viewers/tool-read/index.tsx
@@ -7,8 +7,10 @@ import {
   parseRichContent,
   postProcessText,
 } from "../../shared/content-parser";
+import { inferLang } from "../../shared/language-map";
 import { CodeViewer } from "../../viewers/code-viewer";
 import { ImageViewer } from "../../viewers/image-viewer";
+import { MarkdownViewer } from "../../viewers/markdown-viewer";
 
 interface ToolReadProps {
   input?: string;
@@ -68,10 +70,19 @@ export function ToolRead({
     );
   }
 
+  const isMarkdown = resolvedPath
+    ? inferLang(resolvedPath) === "markdown"
+    : false;
+
   return (
     <div className="space-y-2">
       {svgSrc && <ImageViewer images={[{ src: svgSrc, alt: "SVG preview" }]} />}
-      {cleanContent && !svgSrc && (
+      {cleanContent && !svgSrc && isMarkdown && (
+        <div className="max-h-[600px] overflow-auto rounded-lg border border-border bg-muted/10 px-4 py-3 text-sm leading-relaxed">
+          <MarkdownViewer content={cleanContent} />
+        </div>
+      )}
+      {cleanContent && !svgSrc && !isMarkdown && (
         <CodeViewer
           code={cleanContent}
           filePath={resolvedPath}

--- a/packages/ui/src/modules/session-detail/components/tool-viewers/tool-write/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/tool-viewers/tool-write/index.tsx
@@ -6,9 +6,12 @@ import {
   parseRichContent,
   tryBuildSvgPreview,
 } from "../../shared/content-parser";
+import { inferLang } from "../../shared/language-map";
+import { isPlanFile } from "../../tool-item/constants";
 import { CodeViewer } from "../../viewers/code-viewer";
 import { DiffViewer } from "../../viewers/diff-viewer";
 import { ImageViewer } from "../../viewers/image-viewer";
+import { MarkdownViewer } from "../../viewers/markdown-viewer";
 
 interface ToolWriteProps {
   input?: string;
@@ -46,6 +49,21 @@ export function ToolWrite({
   const writeContent = content ?? newSource;
 
   if (!writeContent) return null;
+
+  const isMarkdown = resolvedPath
+    ? isPlanFile(resolvedPath) || inferLang(resolvedPath) === "markdown"
+    : false;
+
+  // Markdown file (plan, README, etc.): render as formatted markdown
+  if (isMarkdown) {
+    return (
+      <div className="space-y-2">
+        <div className="max-h-[600px] overflow-auto rounded-lg border border-border bg-muted/10 px-4 py-3 text-sm leading-relaxed">
+          <MarkdownViewer content={writeContent} />
+        </div>
+      </div>
+    );
+  }
 
   // Image file: always show image, never diff/code
   if (isImagePath(resolvedPath)) {

--- a/packages/ui/src/modules/session-detail/components/user-bubble/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/user-bubble/index.tsx
@@ -3,7 +3,6 @@
 import { Clock3, User } from "lucide-react";
 import { formatMessageTime } from "../../libs";
 import type { TimelineUserItem } from "../../types";
-import { MarkdownViewer } from "../viewers/markdown-viewer";
 
 interface UserBubbleProps {
   item: TimelineUserItem;
@@ -24,8 +23,15 @@ export function UserBubble({ item }: UserBubbleProps) {
           </span>
         </div>
         <div className="max-h-[220px] overflow-auto pr-2 text-sm leading-6">
-          <MarkdownViewer content={item.text} />
+          <p className="whitespace-pre-wrap break-words">{item.text}</p>
         </div>
+        {item.commandOutput && (
+          <div className="mt-2 rounded-md bg-muted/50 px-3 py-2">
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
+              {item.commandOutput}
+            </pre>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/packages/ui/src/modules/session-detail/components/viewers/diff-viewer/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/viewers/diff-viewer/index.tsx
@@ -65,12 +65,7 @@ export function DiffViewer({
   if (!diffFile) return null;
 
   return (
-    <div
-      className={cn(
-        "overflow-hidden rounded-lg border border-border text-[11px]",
-        className,
-      )}
-    >
+    <div className={cn("overflow-hidden rounded-xl text-[11px]", className)}>
       <div
         className="overflow-x-auto"
         style={
@@ -88,7 +83,7 @@ export function DiffViewer({
         />
       </div>
       {collapsible && (
-        <div className="flex justify-center border-t bg-muted/30 py-0.5">
+        <div className="flex justify-center bg-muted/20 py-0.5">
           <Button
             variant="ghost"
             size="sm"

--- a/packages/ui/src/modules/session-detail/components/viewers/terminal-viewer/index.tsx
+++ b/packages/ui/src/modules/session-detail/components/viewers/terminal-viewer/index.tsx
@@ -18,24 +18,22 @@ export function TerminalViewer({
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-lg border border-border bg-zinc-950 dark:bg-zinc-950",
+        "overflow-hidden rounded-xl bg-muted/20 px-4 py-3",
         className,
       )}
     >
       {command && (
-        <div className="border-b border-zinc-800 px-3 py-2">
-          <pre className="whitespace-pre-wrap break-all font-mono text-[11px] text-zinc-300">
-            <span className="select-none text-green-400">$ </span>
-            {command}
-          </pre>
-        </div>
+        <pre className="whitespace-pre-wrap break-all font-mono text-xs text-foreground">
+          <span className="select-none text-primary/60">$ </span>
+          {command}
+        </pre>
       )}
       {output && (
-        <div className="max-h-[400px] overflow-auto px-3 py-2">
+        <div className={cn("max-h-[400px] overflow-auto", command && "mt-2")}>
           <pre
             className={cn(
-              "whitespace-pre-wrap break-words font-mono text-[11px]",
-              isError ? "text-red-400" : "text-zinc-400",
+              "whitespace-pre-wrap break-words font-mono text-xs",
+              isError ? "text-destructive/80" : "text-muted-foreground",
             )}
           >
             {output}

--- a/packages/ui/src/modules/session-detail/index.tsx
+++ b/packages/ui/src/modules/session-detail/index.tsx
@@ -9,6 +9,7 @@ import {
   SessionHighlights,
   TimelineItem,
 } from "./components";
+import { ReplayBar } from "./components/replay-bar";
 import type { SessionDetailModuleProps } from "./types";
 import { useService } from "./use-service";
 
@@ -29,6 +30,7 @@ export function SessionDetail({ sessionPath }: SessionDetailModuleProps) {
     onBack,
     isLoading,
     error,
+    replay,
   } = useService(sessionPath);
 
   if (error && !isLoading) {
@@ -64,6 +66,7 @@ export function SessionDetail({ sessionPath }: SessionDetailModuleProps) {
             stats={sessionDetail.stats}
             collapsed={isTopCollapsed}
             onBack={onBack}
+            onReplay={replay.isReplaying ? undefined : replay.startReplay}
           />
           {!isTopCollapsed && highlights && (
             <SessionHighlights highlights={highlights} />
@@ -103,7 +106,7 @@ export function SessionDetail({ sessionPath }: SessionDetailModuleProps) {
               </div>
             </div>
 
-            {isSessionActive && (
+            {isSessionActive && !replay.isReplaying && (
               <div className="flex items-center gap-1.5 px-4 py-3">
                 <span className="inline-flex gap-1">
                   <span className="size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.3s]" />
@@ -116,10 +119,24 @@ export function SessionDetail({ sessionPath }: SessionDetailModuleProps) {
               </div>
             )}
 
-            <ScrollToBottomButton
-              visible={showScrollToBottom}
-              onClick={scrollToBottom}
-            />
+            {replay.isReplaying ? (
+              <ReplayBar
+                isPlaying={replay.isPlaying}
+                progress={replay.progress}
+                speed={replay.speed}
+                visibleCount={replay.visibleCount}
+                totalCount={replay.totalCount}
+                onTogglePlay={replay.togglePlay}
+                onStop={replay.stopReplay}
+                onSpeedChange={replay.setSpeed}
+                onSeek={replay.seek}
+              />
+            ) : (
+              <ScrollToBottomButton
+                visible={showScrollToBottom}
+                onClick={scrollToBottom}
+              />
+            )}
           </div>
         )}
       </div>

--- a/packages/ui/src/modules/session-detail/libs.ts
+++ b/packages/ui/src/modules/session-detail/libs.ts
@@ -5,8 +5,15 @@ import type {
 import {
   extractSlashCommand,
   sanitizeMessageText,
+  stripAnsiCodes,
 } from "./components/shared/text-utils";
-import type { TimelineItem, TimelineUserItem } from "./types";
+import type {
+  TimelineItem,
+  TimelineToolGroupItem,
+  TimelineToolItem,
+  TimelineUserItem,
+  ToolGroupCategory,
+} from "./types";
 
 export interface SessionHighlights {
   toolCalls: number;
@@ -161,28 +168,11 @@ function buildFlatMessageItems(
     }
 
     if (block.type === "text") {
-      const text = block.text?.trim();
-      if (!text || isInterruptionText(text)) continue;
+      const rawText = block.text?.trim();
+      if (!rawText || isInterruptionText(rawText)) continue;
 
-      if (role === "user") {
-        // User text in a tool-result message — still show as assistant context
-        items.push({
-          id: `${message.uuid}-text-${index}`,
-          kind: "assistant",
-          timestamp: message.timestamp,
-          text,
-          model: message.model,
-        });
-      } else {
-        items.push({
-          id: `${message.uuid}-text-${index}`,
-          kind: "assistant",
-          timestamp: message.timestamp,
-          text,
-          model: message.model,
-        });
-      }
-      continue;
+      const handled = routeTextBlock(rawText, message, index, items);
+      if (handled) continue;
     }
 
     if (block.type === "tool_use" && block.name?.trim() && block.toolUseId) {
@@ -230,28 +220,22 @@ function buildFlatMessageItems(
 }
 
 function extractUserItem(message: ClaudeMessage): TimelineUserItem | null {
+  // Use routeTextBlock for consistent handling of all text formats.
+  // Collect items, then return the first user item (if any).
+  const items: TimelineItem[] = [];
+
   for (const [index, block] of (message.blocks ?? []).entries()) {
     if (block.type !== "text" || !block.text?.trim()) continue;
 
     const rawText = block.text.trim();
     if (isInterruptionText(rawText)) continue;
 
-    const command = extractSlashCommand(rawText);
-    const text = command
-      ? `/${command.name}${command.args ? ` ${command.args}` : ""}`
-      : sanitizeMessageText(rawText);
-
-    if (!text.trim()) continue;
-
-    return {
-      id: `${message.uuid}-prompt-${index}`,
-      kind: "user",
-      timestamp: message.timestamp,
-      text: text.trim(),
-    };
+    routeTextBlock(rawText, message, index, items);
   }
 
-  return null;
+  // Return the first user item, with any commandOutput attached
+  const firstUser = items.find((i) => i.kind === "user");
+  return (firstUser as TimelineUserItem) ?? null;
 }
 
 function mergeAdjacentAssistantItems(items: TimelineItem[]): TimelineItem[] {
@@ -339,4 +323,171 @@ function normalizeRole(
 ): "user" | "assistant" | "system" {
   if (type === "assistant" || type === "system") return type;
   return "user";
+}
+
+/**
+ * Route a text block to the correct timeline item type.
+ * Handles all Claude Code special message formats:
+ * - caveat messages (hidden)
+ * - slash commands (/config, /exit)
+ * - command stdout/stderr output
+ * - regular user text
+ * - assistant/system text with metadata sanitization
+ *
+ * Returns true if handled (item pushed or skipped), false if caller should handle.
+ */
+function routeTextBlock(
+  rawText: string,
+  message: ClaudeMessage,
+  blockIndex: number,
+  items: TimelineItem[],
+): boolean {
+  const role = normalizeRole(message.type);
+
+  // 1. Caveat messages — always hide
+  if (rawText.startsWith("<local-command-caveat>")) {
+    return true; // skip
+  }
+
+  // 2. Slash command metadata — parse as /command
+  const command = extractSlashCommand(rawText);
+  if (command) {
+    const commandOutput = command.stdout
+      ? stripAnsiCodes(command.stdout).trim() || undefined
+      : undefined;
+    const name = command.name.startsWith("/")
+      ? command.name
+      : `/${command.name}`;
+    items.push({
+      id: `${message.uuid}-prompt-${blockIndex}`,
+      kind: "user",
+      timestamp: message.timestamp,
+      text: `${name}${command.args ? ` ${command.args}` : ""}`,
+      commandOutput,
+    });
+    return true;
+  }
+
+  // 3. Command stdout/stderr — attach to previous command or show inline
+  if (
+    rawText.startsWith("<local-command-stdout>") ||
+    rawText.startsWith("<local-command-stderr>") ||
+    rawText.startsWith("<bash-stdout>") ||
+    rawText.startsWith("<bash-stderr>")
+  ) {
+    const content = extractTagContent(rawText);
+    if (!content) return true; // empty output, skip
+
+    const cleaned = stripAnsiCodes(content).trim();
+    if (!cleaned) return true;
+
+    // Try to attach to the previous user item as commandOutput
+    const lastItem = items[items.length - 1];
+    if (lastItem?.kind === "user" && !lastItem.commandOutput) {
+      lastItem.commandOutput = cleaned;
+      return true;
+    }
+
+    // Otherwise show as standalone muted output
+    items.push({
+      id: `${message.uuid}-text-${blockIndex}`,
+      kind: "user",
+      timestamp: message.timestamp,
+      text: cleaned,
+    });
+    return true;
+  }
+
+  // 4. User text — show as-is (plain text, no markdown processing)
+  if (role === "user") {
+    items.push({
+      id: `${message.uuid}-text-${blockIndex}`,
+      kind: "user",
+      timestamp: message.timestamp,
+      text: rawText,
+    });
+    return true;
+  }
+
+  // 5. Assistant/system text — sanitize metadata tags
+  const text = sanitizeMessageText(rawText);
+  if (!text) return true;
+
+  items.push({
+    id: `${message.uuid}-text-${blockIndex}`,
+    kind: "assistant",
+    timestamp: message.timestamp,
+    text,
+    model: message.model,
+  });
+  return true;
+}
+
+/** Extract content from a tag like `<local-command-stdout>content</local-command-stdout>` */
+function extractTagContent(text: string): string | null {
+  const match = text.match(/^<[^>]+>([\s\S]*)<\/[^>]+>$/);
+  return match?.[1] ?? null;
+}
+
+/* ── Consecutive tool grouping ─────────────────────────────────── */
+
+const READ_TOOLS = new Set(["Read", "Glob"]);
+const SEARCH_TOOLS = new Set(["Grep", "WebSearch", "WebFetch"]);
+
+function getGroupCategory(toolName: string): ToolGroupCategory | null {
+  if (READ_TOOLS.has(toolName)) return "read";
+  if (SEARCH_TOOLS.has(toolName)) return "search";
+  return null;
+}
+
+/**
+ * Post-process a flat timeline: merge consecutive read or search tool items
+ * into `tool-group` items (minimum 2 to form a group).
+ */
+export function groupConsecutiveTools(items: TimelineItem[]): TimelineItem[] {
+  const result: TimelineItem[] = [];
+  let pendingGroup: TimelineToolItem[] = [];
+  let pendingCategory: ToolGroupCategory | null = null;
+
+  const flushGroup = () => {
+    if (pendingGroup.length >= 2 && pendingCategory) {
+      const group: TimelineToolGroupItem = {
+        id: `group-${pendingGroup[0].id}`,
+        kind: "tool-group",
+        timestamp: pendingGroup[0].timestamp,
+        category: pendingCategory,
+        items: pendingGroup,
+      };
+      result.push(group);
+    } else {
+      result.push(...pendingGroup);
+    }
+    pendingGroup = [];
+    pendingCategory = null;
+  };
+
+  for (const item of items) {
+    if (item.kind === "tool" && !item.isError) {
+      const cat = getGroupCategory(item.toolName);
+      if (cat && (pendingCategory === null || pendingCategory === cat)) {
+        pendingCategory = cat;
+        pendingGroup.push(item);
+        continue;
+      }
+    }
+    // Item doesn't belong to current group — flush and push
+    flushGroup();
+    if (item.kind === "tool" && !item.isError) {
+      const cat = getGroupCategory(item.toolName);
+      if (cat) {
+        pendingCategory = cat;
+        pendingGroup.push(item);
+        continue;
+      }
+    }
+    result.push(item);
+  }
+
+  flushGroup();
+  return result;
 }

--- a/packages/ui/src/modules/session-detail/types.ts
+++ b/packages/ui/src/modules/session-detail/types.ts
@@ -22,6 +22,8 @@ export interface TimelineUserItem {
   kind: "user";
   timestamp: string;
   text: string;
+  /** Output from a slash command (e.g. /compact), ANSI-stripped. */
+  commandOutput?: string;
 }
 
 export interface TimelineAssistantItem {
@@ -54,14 +56,39 @@ export interface TimelineThinkingItem {
   redacted: boolean;
 }
 
+export type ToolGroupCategory = "read" | "search";
+
+export interface TimelineToolGroupItem {
+  id: string;
+  kind: "tool-group";
+  timestamp: string;
+  category: ToolGroupCategory;
+  items: TimelineToolItem[];
+}
+
 export type TimelineItem =
   | TimelineUserItem
   | TimelineAssistantItem
   | TimelineToolItem
-  | TimelineThinkingItem;
+  | TimelineThinkingItem
+  | TimelineToolGroupItem;
 
 export interface SessionDetailModuleProps {
   sessionPath: string;
+}
+
+export interface ReplayControls {
+  isReplaying: boolean;
+  isPlaying: boolean;
+  progress: number;
+  speed: import("./use-replay").ReplaySpeed;
+  visibleCount: number;
+  totalCount: number;
+  startReplay: () => void;
+  stopReplay: () => void;
+  togglePlay: () => void;
+  setSpeed: (speed: import("./use-replay").ReplaySpeed) => void;
+  seek: (progress: number) => void;
 }
 
 export interface UseServiceReturn {
@@ -80,4 +107,5 @@ export interface UseServiceReturn {
   isSessionActive: boolean;
   isLoading: boolean;
   error: Error | null;
+  replay: ReplayControls;
 }

--- a/packages/ui/src/modules/session-detail/use-replay.ts
+++ b/packages/ui/src/modules/session-detail/use-replay.ts
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TimelineItem } from "./types";
+
+export type ReplaySpeed = 1 | 2 | 4 | 8;
+
+export interface UseReplayReturn {
+  /** Whether replay mode is active */
+  isReplaying: boolean;
+  /** Whether replay is currently playing (vs paused) */
+  isPlaying: boolean;
+  /** Current visible item count (0 = all items visible, replay off) */
+  visibleCount: number;
+  /** Current playback speed */
+  speed: ReplaySpeed;
+  /** Start replay from beginning */
+  startReplay: () => void;
+  /** Stop replay and show all items */
+  stopReplay: () => void;
+  /** Toggle play/pause */
+  togglePlay: () => void;
+  /** Change playback speed */
+  setSpeed: (speed: ReplaySpeed) => void;
+  /** Seek to a specific position (0-1) */
+  seek: (progress: number) => void;
+  /** Progress value 0-1 */
+  progress: number;
+}
+
+/** Maximum gap between items in ms (real time), to avoid long waits. */
+const MAX_GAP_MS = 2000;
+/** Minimum gap between items in ms. */
+const MIN_GAP_MS = 150;
+
+/**
+ * Computes the delay before revealing the next item, based on timestamps.
+ * Falls back to a fixed interval if timestamps are missing or identical.
+ */
+function getDelay(
+  items: TimelineItem[],
+  currentIndex: number,
+  speed: ReplaySpeed,
+): number {
+  if (currentIndex <= 0 || currentIndex >= items.length) {
+    return MIN_GAP_MS / speed;
+  }
+
+  const prev = items[currentIndex - 1];
+  const curr = items[currentIndex];
+
+  if (!prev.timestamp || !curr.timestamp) {
+    return MIN_GAP_MS / speed;
+  }
+
+  const delta =
+    new Date(curr.timestamp).getTime() - new Date(prev.timestamp).getTime();
+
+  if (delta <= 0 || Number.isNaN(delta)) {
+    return MIN_GAP_MS / speed;
+  }
+
+  const clamped = Math.min(Math.max(delta, MIN_GAP_MS), MAX_GAP_MS);
+  return clamped / speed;
+}
+
+export function useReplay(items: TimelineItem[]): UseReplayReturn {
+  const [isReplaying, setIsReplaying] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(0);
+  const [speed, setSpeed] = useState<ReplaySpeed>(1);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const itemsRef = useRef(items);
+  const speedRef = useRef(speed);
+  itemsRef.current = items;
+  speedRef.current = speed;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Schedule the next tick
+  const scheduleNext = useCallback(
+    (currentCount: number) => {
+      clearTimer();
+      const allItems = itemsRef.current;
+      if (currentCount >= allItems.length) {
+        // Replay finished
+        setIsPlaying(false);
+        return;
+      }
+      const delay = getDelay(allItems, currentCount, speedRef.current);
+      timerRef.current = setTimeout(() => {
+        const nextCount = currentCount + 1;
+        setVisibleCount(nextCount);
+        scheduleNext(nextCount);
+      }, delay);
+    },
+    [clearTimer],
+  );
+
+  const startReplay = useCallback(() => {
+    clearTimer();
+    setVisibleCount(1);
+    setIsReplaying(true);
+    setIsPlaying(true);
+    // Schedule from index 1
+    requestAnimationFrame(() => {
+      scheduleNext(1);
+    });
+  }, [clearTimer, scheduleNext]);
+
+  const stopReplay = useCallback(() => {
+    clearTimer();
+    setIsReplaying(false);
+    setIsPlaying(false);
+    setVisibleCount(0);
+  }, [clearTimer]);
+
+  const togglePlay = useCallback(() => {
+    if (!isReplaying) return;
+    if (isPlaying) {
+      // Pause
+      clearTimer();
+      setIsPlaying(false);
+    } else {
+      // Resume (or restart if finished)
+      setIsPlaying(true);
+      const count = visibleCount >= itemsRef.current.length ? 1 : visibleCount;
+      if (count === 1) setVisibleCount(1);
+      scheduleNext(count);
+    }
+  }, [isReplaying, isPlaying, visibleCount, clearTimer, scheduleNext]);
+
+  const seek = useCallback(
+    (progress: number) => {
+      const total = itemsRef.current.length;
+      if (total === 0) return;
+      const target = Math.max(1, Math.round(progress * total));
+      clearTimer();
+      setVisibleCount(target);
+      if (isPlaying && target < total) {
+        scheduleNext(target);
+      } else if (target >= total) {
+        setIsPlaying(false);
+      }
+    },
+    [isPlaying, clearTimer, scheduleNext],
+  );
+
+  const progress =
+    items.length === 0 ? 0 : isReplaying ? visibleCount / items.length : 1;
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return clearTimer;
+  }, [clearTimer]);
+
+  return {
+    isReplaying,
+    isPlaying,
+    visibleCount,
+    speed,
+    startReplay,
+    stopReplay,
+    togglePlay,
+    setSpeed,
+    seek,
+    progress,
+  };
+}

--- a/packages/ui/src/modules/session-detail/use-service.ts
+++ b/packages/ui/src/modules/session-detail/use-service.ts
@@ -8,8 +8,13 @@ import { ClaudeSessionBridge } from "@/bridges/claude-session-bridge";
 import { useScrollToBottom } from "@/hooks/use-scroll-to-bottom";
 import { useTauriEvent } from "@/hooks/use-tauri-event";
 import { watcherBackedQueryOptions } from "@/lib/query-options";
-import { buildFlatTimeline, buildSessionHighlights } from "./libs";
+import {
+  buildFlatTimeline,
+  buildSessionHighlights,
+  groupConsecutiveTools,
+} from "./libs";
 import type { UseServiceReturn } from "./types";
+import { useReplay } from "./use-replay";
 
 const TOP_PANEL_SHOW_THRESHOLD = 24;
 const TOP_PANEL_HIDE_THRESHOLD = 260;
@@ -69,7 +74,10 @@ export function useService(sessionPath: string): UseServiceReturn {
   const previousItemCountRef = useRef(0);
 
   const timelineItems = useMemo(
-    () => buildFlatTimeline(detailQuery.data?.messages ?? []),
+    () =>
+      groupConsecutiveTools(
+        buildFlatTimeline(detailQuery.data?.messages ?? []),
+      ),
     [detailQuery.data?.messages],
   );
 
@@ -78,11 +86,18 @@ export function useService(sessionPath: string): UseServiceReturn {
     return buildSessionHighlights(detailQuery.data.messages ?? []);
   }, [detailQuery.data]);
 
+  const replay = useReplay(timelineItems);
+
+  // During replay, only show items up to visibleCount
+  const displayItems = replay.isReplaying
+    ? timelineItems.slice(0, replay.visibleCount)
+    : timelineItems;
+
   const virtualizer = useVirtualizer({
-    count: timelineItems.length,
+    count: displayItems.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: (index) => {
-      const item = timelineItems[index];
+      const item = displayItems[index];
       if (!item) return 90;
       switch (item.kind) {
         case "user":
@@ -90,9 +105,16 @@ export function useService(sessionPath: string): UseServiceReturn {
         case "assistant":
           return 120;
         case "tool":
-          return 52;
+          // Inline tools (Edit/Write/Bash) are taller; compact tools (Read/Search) are tiny
+          return item.toolName === "Edit" ||
+            item.toolName === "Write" ||
+            item.toolName === "Bash"
+            ? 160
+            : 24;
         case "thinking":
-          return 44;
+          return 24;
+        case "tool-group":
+          return 24;
         default:
           return 90;
       }
@@ -101,24 +123,38 @@ export function useService(sessionPath: string): UseServiceReturn {
   });
 
   const handleScrollToBottom = useCallback(() => {
-    if (timelineItems.length === 0) return;
-    virtualizer.scrollToIndex(timelineItems.length - 1, {
-      align: "end",
-      behavior: "smooth",
-    });
-  }, [virtualizer, timelineItems.length]);
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }, []);
 
-  const { showScrollToBottom, isNearBottom, scrollToBottom } =
-    useScrollToBottom({
-      scrollRef,
-      itemCount: timelineItems.length,
-      onScrollToBottom: handleScrollToBottom,
-      autoScrollOnInitialLoad: false,
-    });
+  const { showScrollToBottom, scrollToBottom } = useScrollToBottom({
+    scrollRef,
+    itemCount: timelineItems.length,
+    onScrollToBottom: handleScrollToBottom,
+    autoScrollOnInitialLoad: false,
+  });
+
+  /** Check if user is near bottom RIGHT NOW (not from stale state). */
+  const checkIsNearBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return true;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    return distance <= LIVE_FOLLOW_THRESHOLD_PX;
+  }, []);
 
   const onBack = useCallback(() => {
     router.push("/sessions");
   }, [router]);
+
+  // Auto-scroll during replay as items are revealed
+  useEffect(() => {
+    if (!replay.isReplaying || !replay.isPlaying) return;
+    if (displayItems.length === 0) return;
+    requestAnimationFrame(() => {
+      virtualizer.scrollToIndex(displayItems.length - 1, { align: "end" });
+    });
+  }, [replay.isReplaying, replay.isPlaying, displayItems.length, virtualizer]);
 
   useEffect(() => {
     hasPreparedInitialRenderRef.current = false;
@@ -179,7 +215,7 @@ export function useService(sessionPath: string): UseServiceReturn {
     previousItemCountRef.current = timelineItems.length;
 
     if (!isFirstRender) {
-      if (timelineItems.length > previousCount && isNearBottom) {
+      if (timelineItems.length > previousCount && checkIsNearBottom()) {
         requestAnimationFrame(() => {
           virtualizer.scrollToIndex(timelineItems.length - 1, {
             align: "end",
@@ -231,13 +267,13 @@ export function useService(sessionPath: string): UseServiceReturn {
     detailQuery.error,
     detailQuery.data,
     timelineItems.length,
-    isNearBottom,
+    checkIsNearBottom,
     virtualizer,
   ]);
 
   return {
     sessionDetail: detailQuery.data ?? null,
-    timelineItems,
+    timelineItems: displayItems,
     totalMessageCount: detailQuery.data?.messages.length ?? 0,
     totalTurnCount: timelineItems.filter((item) => item.kind === "user").length,
     highlights,
@@ -251,5 +287,18 @@ export function useService(sessionPath: string): UseServiceReturn {
     isSessionActive,
     isLoading: detailQuery.isLoading,
     error: detailQuery.error as Error | null,
+    replay: {
+      isReplaying: replay.isReplaying,
+      isPlaying: replay.isPlaying,
+      progress: replay.progress,
+      speed: replay.speed,
+      visibleCount: replay.visibleCount,
+      totalCount: timelineItems.length,
+      startReplay: replay.startReplay,
+      stopReplay: replay.stopReplay,
+      togglePlay: replay.togglePlay,
+      setSpeed: replay.setSpeed,
+      seek: replay.seek,
+    },
   };
 }

--- a/packages/ui/src/modules/sessions/components/session-list/index.tsx
+++ b/packages/ui/src/modules/sessions/components/session-list/index.tsx
@@ -4,6 +4,7 @@ import { Clock, MessageSquare } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cleanDisplayText } from "@/modules/session-detail/components/shared/text-utils";
 import { formatTimeAgo, truncate } from "../../libs";
 import type { SessionListProps } from "./types";
 
@@ -69,8 +70,9 @@ export function SessionList({
               <CardContent className="px-3 py-0 md:px-4">
                 <div className="flex items-start justify-between gap-3">
                   <p className="line-clamp-2 min-w-0 flex-1 text-sm font-medium leading-6">
-                    {session.summary ||
-                      truncate(session.firstPrompt || "No prompt", 100)}
+                    {cleanDisplayText(
+                      session.summary || session.firstPrompt || "",
+                    ) || "No prompt"}
                   </p>
                   <div className="mt-0.5 flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
                     <Clock className="size-3" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4

--- a/src-tauri/src/services/claude_session_service.rs
+++ b/src-tauri/src/services/claude_session_service.rs
@@ -19,6 +19,8 @@ struct SessionMeta {
     full_path: String,
     is_sidechain: bool,
     first_prompt: Option<String>,
+    /// AI-generated session title from `custom-title` JSONL entries.
+    custom_title: Option<String>,
     cwd: Option<String>,
     first_timestamp: Option<String>,
     mtime_ms: i64,
@@ -176,6 +178,34 @@ impl ClaudeSessionService {
         })
     }
 
+    /// Extract the AI-generated session title from `custom-title` JSONL entries.
+    /// Scans the file by searching for the literal string to avoid parsing every line.
+    fn extract_custom_title(jsonl_path: &Path) -> Option<String> {
+        let content = fs::read_to_string(jsonl_path).ok()?;
+        // Fast check: avoid JSON parsing if the marker isn't present at all
+        if !content.contains("\"custom-title\"") {
+            return None;
+        }
+        // Find the LAST custom-title entry (in case there are updates)
+        let mut title: Option<String> = None;
+        for line in content.lines().rev() {
+            if !line.contains("\"custom-title\"") {
+                continue;
+            }
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(line) {
+                if val.get("type").and_then(|v| v.as_str()) == Some("custom-title") {
+                    if let Some(t) = val.get("customTitle").and_then(|v| v.as_str()) {
+                        if !t.is_empty() {
+                            title = Some(t.to_string());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        title
+    }
+
     /// Extract lightweight metadata from a .jsonl session file.
     /// Reads only the first few conversational records to keep list loading fast.
     fn extract_session_meta(jsonl_path: &Path) -> Option<SessionMeta> {
@@ -281,11 +311,16 @@ impl ClaudeSessionService {
             }
         }
 
+        // Scan for AI-generated custom-title (can appear anywhere in the file).
+        // Read from the tail since it's typically written after the first turn.
+        let custom_title = Self::extract_custom_title(jsonl_path);
+
         Some(SessionMeta {
             session_id: file_name,
             full_path,
             is_sidechain,
             first_prompt: first_prompt.or(command_fallback),
+            custom_title,
             cwd,
             first_timestamp,
             mtime_ms,
@@ -425,7 +460,7 @@ impl ClaudeSessionService {
             session_id: meta.session_id.clone(),
             full_path: meta.full_path.clone(),
             first_prompt: meta.first_prompt.clone(),
-            summary: None,
+            summary: meta.custom_title.clone(),
             message_count: meta.message_count,
             created,
             modified,


### PR DESCRIPTION
## Summary

- **Ambient document layout**: Replace card-based tool rendering with content-first design — Edit/Write diffs visible inline, Read/Search as compact single lines, Bash output directly shown
- **Session replay**: Progressive timeline reveal with timestamp-based pacing, play/pause, speed control (1x/2x/4x/8x), seekable progress bar
- **Claude Code XML tag handling**: Proper routing for slash commands, caveat messages, stdout/stderr blocks; user text preserved as-is
- **Session titles**: Extract AI-generated `custom-title` from JSONL for meaningful titles instead of raw first prompts
- **MarkdownViewer**: `remarkPreserveHtml` plugin prevents unknown HTML tags from being silently stripped
- **Scroll fixes**: Fix scroll-to-bottom button not appearing; use native smooth scrolling

## Test plan

- [x] Open a session with many tool calls — verify Edit diffs visible inline, Read/Search are compact single lines
- [x] Open a session with slash commands (/config, /exit) — verify rendered as `/config`, `/exit` with stdout output
- [x] Open a session where user typed literal `<tag>` content — verify displayed as-is, not stripped
- [x] Test replay: click play button in header, verify progressive reveal with auto-scroll
- [x] Test replay controls: pause/resume, speed change, progress bar seek, stop
- [x] Verify session titles show AI-generated custom-title when available
- [x] Scroll up in a long session — verify scroll-to-bottom button appears and scrolls smoothly
- [x] Verify no regressions in assistant text, thinking blocks, user bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)